### PR TITLE
Raise a more useful error when `default` is not valid

### DIFF
--- a/fluent/fields.py
+++ b/fluent/fields.py
@@ -245,6 +245,13 @@ class TranslatableCharField(models.ForeignKey):
 
         setattr(cls, self.name, TranslatableFieldDescriptor(self))
 
+    def get_default(self):
+        val = super(TranslatableCharField, self).get_default()
+
+        # default value might be None (blank=True)
+        if not isinstance(val, TranslatableContent) and val is not None:
+            raise ValueError("Default value of {} must be a TranslatableContent instance".format(self.name))
+
     # Model mummy fix to always force creation
     @property
     def fill_optional(self):

--- a/fluent/fields.py
+++ b/fluent/fields.py
@@ -201,15 +201,15 @@ class TranslatableCharField(models.ForeignKey):
         # Now, subclass it so we can add our own magic
         class TranslatableFieldDescriptor(klass):
             def __get__(self, instance, instance_type):
-                # First, do we have a content attribute already, if so, return it
-                existing = getattr(instance, CACHE_ATTRIBUTE, None)
+                # First, do we have a content attribute or non-None default already,
+                # if so, return it
+                existing = getattr(instance, CACHE_ATTRIBUTE, self.field.get_default())
                 if existing:
                     return existing
 
                 # If we don't, but we do have a master translation, then create a new content
                 # attribute from that
                 master_translation = super(TranslatableFieldDescriptor, self).__get__(instance, instance_type)
-
                 if master_translation:
                     new_content = TranslatableContent(
                         hint=self.field.hint,
@@ -251,6 +251,8 @@ class TranslatableCharField(models.ForeignKey):
         # default value might be None (blank=True)
         if not isinstance(val, TranslatableContent) and val is not None:
             raise ValueError("Default value of {} must be a TranslatableContent instance".format(self.name))
+
+        return val
 
     # Model mummy fix to always force creation
     @property

--- a/fluent/tests/test_fields.py
+++ b/fluent/tests/test_fields.py
@@ -23,6 +23,14 @@ class TestModel(models.Model):
     trans_with_group = TranslatableCharField(group="Test", blank=True)
 
 
+class TestBadDefaultModel(models.Model):
+    class Meta:
+        # don't get counted in the locating test
+        app_label = "fluent_test"
+
+    trans = TranslatableCharField(default="Not a TranslatableContent object")
+
+
 class TranslatableCharFieldTests(TestCase):
 
     def test_unset_translations(self):
@@ -54,6 +62,13 @@ class TranslatableCharFieldTests(TestCase):
 
         translations = MasterTranslation.find_by_group("Test")
         self.assertEqual(1, translations.count())
+
+    def test_bad_default_error(self):
+        """
+        A non-TranslatableContent default value should raise a ValueError
+        """
+        with self.assertRaises(ValueError):
+            TestBadDefaultModel.objects.create()
 
     def test_with_model_mommy(self):
         monkey_patch()  # Enable custom generator

--- a/fluent/tests/test_fields.py
+++ b/fluent/tests/test_fields.py
@@ -21,6 +21,7 @@ class TestModel(models.Model):
     trans = TranslatableCharField(blank=True)
     trans_with_hint = TranslatableCharField(hint="Test", blank=True)
     trans_with_group = TranslatableCharField(group="Test", blank=True)
+    trans_with_default = TranslatableCharField(blank=True, default=TranslatableContent(text="Adirondack"))
 
 
 class TestBadDefaultModel(models.Model):
@@ -39,12 +40,14 @@ class TranslatableCharFieldTests(TestCase):
         self.assertEqual("", m.trans.text)
         self.assertEqual("", m.trans_with_hint.text)
         self.assertEqual("", m.trans_with_group.text)
+        self.assertEqual("Adirondack", m.trans_with_default.text)
 
         m.save()
 
         self.assertEqual("", m.trans.text)
         self.assertEqual("", m.trans_with_hint.text)
         self.assertEqual("", m.trans_with_group.text)
+        self.assertEqual("Adirondack", m.trans_with_default.text)
 
     def test_setting_translation_text(self):
         m = TestModel()
@@ -84,11 +87,12 @@ class TestLocatingTranslatableFields(TestCase):
         # Just filter the results down to this app
         results = [ x for x in results if x[0]._meta.app_label == "fluent" ]
 
-        # Should return the 3 fields of TestModel above
-        self.assertEqual(3, len(results))
+        # Should return the 4 fields of TestModel above
+        self.assertEqual(4, len(results))
         self.assertEqual(TestModel, results[0][0])
         self.assertEqual(TestModel, results[1][0])
         self.assertEqual(TestModel, results[2][0])
+        self.assertEqual(TestModel, results[3][0])
 
         results = find_all_translatable_fields(with_group="Test")
         # Just filter the results down to this app


### PR DESCRIPTION
Setting the default value of a translatable field to a string would
raise a cryptic `MasterTranslation.DoesNotExist` exception.

Instead, we should raise a `ValueError` as we do when a field is set and
explicitly state that a default value is the issue.