### PR TITLE
text_for_language_code didn't account for default values

### DIFF
--- a/fluent/fields.py
+++ b/fluent/fields.py
@@ -87,7 +87,11 @@ class TranslatableContent(object):
 
     def text_for_language_code(self, language_code):
         self._load_master_translation()
-        return self._master_translation_cache.text_for_language_code(language_code)
+        if self._master_translation_cache:
+            return self._master_translation_cache.text_for_language_code(language_code)
+        else:
+            # we don't have a master translation (or it failed to load)
+            return self.text
 
     def save(self):
         if self.is_effectively_null:

--- a/fluent/tests/test_fields.py
+++ b/fluent/tests/test_fields.py
@@ -49,6 +49,9 @@ class TranslatableCharFieldTests(TestCase):
         self.assertEqual("", m.trans_with_group.text)
         self.assertEqual("Adirondack", m.trans_with_default.text)
 
+        self.assertEqual(m.trans.text_for_language_code("en"), "")
+        self.assertEqual(m.trans_with_default.text_for_language_code("en"), "Adirondack")
+
     def test_setting_and_getting_translation_text(self):
         m = TestModel()
         m.trans.text = "Hello World!"


### PR DESCRIPTION
`TranslatableContent.text_for_language_code` now checks that there is
actually a master translation to check. If not, it just returns the
default value.