### PR TITLE
Generate hash for unicode

### DIFF
--- a/fluent/models.py
+++ b/fluent/models.py
@@ -71,6 +71,7 @@ class Translation(models.Model):
 
         result = md5()
         for x in (master_text, master_hint):
+            x = x.encode('utf-8')
             result.update(x)
         return result.hexdigest()
 

--- a/fluent/models.py
+++ b/fluent/models.py
@@ -89,7 +89,7 @@ class Translation(models.Model):
             self.denorm_master_text,
             self.denorm_master_hint
         )
-        super(Translation, self).save(*args, **kwargs)
+        return super(Translation, self).save(*args, **kwargs)
 
 
 class MasterTranslation(models.Model):

--- a/fluent/tests/test_models.py
+++ b/fluent/tests/test_models.py
@@ -54,3 +54,10 @@ class TranslationTests(TestCase):
         translation.plural_texts["o"] = "Buttons%s"
         with self.assertRaises(ValidationError):
             translation.full_clean()
+
+    def test_can_create_translation_from_non_ascii_master(self):
+        master_text = u'\u0141uk\u0105\u015b\u017a' # Lukasz.
+        mt = MasterTranslation.objects.create(text=master_text)
+
+        # Previously this would raise UnicodeEncodeError.
+        mt.create_or_update_translation('en', singular_text=u'Lukasz')


### PR DESCRIPTION
Hello,

This change fixes a UnicodeEncodeError exception that is raised when the master text has non-ASCII text.

It also makes sure that Translation.save() returns the newly-saved instance.

Only thing is I think I broke another test "test_memcache_invalidates_when_the_request_ends", I'm guessing some state is leaking between each test.