### PR TITLE
Add __unicode__ method to Translation model

### DIFF
--- a/fluent/models.py
+++ b/fluent/models.py
@@ -65,10 +65,7 @@ class Translation(models.Model):
             raise ValidationError([err for err, _orig, _trans in msgs])
 
     def __unicode__(self):
-        single_form_key = get_plural_index(self.language_code, 1)
-        plural_keys = self.plural_texts.keys()
-        plural_keys.remove(single_form_key)
-        return u"{} ({}{})".format(self.text, self.language_code, ' plural' if len(plural_keys) > 0 else '')
+        return u"Translation of {} for {}".format(self.denorm_master_text, self.language_code)
 
     @staticmethod
     def generate_hash(master_text, master_hint):

--- a/fluent/models.py
+++ b/fluent/models.py
@@ -64,6 +64,12 @@ class Translation(models.Model):
         if msgs:
             raise ValidationError([err for err, _orig, _trans in msgs])
 
+    def __unicode__(self):
+        single_form_key = get_plural_index(self.language_code, 1)
+        plural_keys = self.plural_texts.keys()
+        plural_keys.remove(single_form_key)
+        return u"{} ({}{})".format(self.text, self.language_code, ' plural' if len(plural_keys) > 0 else '')
+
     @staticmethod
     def generate_hash(master_text, master_hint):
         assert master_text

--- a/fluent/tests/test_models.py
+++ b/fluent/tests/test_models.py
@@ -44,8 +44,48 @@ class MasterTranslationTests(TestCase):
         text = mt.text_for_language_code("de")
         self.assertEqual(text, "Hallo Welt!")
 
+    def test_unicode_magic_single(self):
+        mt = MasterTranslation.objects.create(
+            text="Hello",
+            hint="World!",
+            language_code="en"
+        )
+
+        self.assertEqual(unicode(mt), "Hello (en)")
+
+    def test_unicode_magic_plural(self):
+        mt = MasterTranslation.objects.create(
+            text="Hello",
+            plural_text={"h": "Helloes"},
+            hint="World!",
+            language_code="en"
+        )
+
+        self.assertEqual(unicode(mt), "Hello (en plural)")
+
 
 class TranslationTests(TestCase):
+    def test_unicode_magic_single(self):
+        mt = MasterTranslation.objects.create(
+            text="Hello",
+            hint="World!",
+            language_code="en"
+        )
+        translation = Translation.objects.get()
+
+        self.assertEqual(unicode(mt), "Hello (en)")
+
+    def test_unicode_magic_plural(self):
+        mt = MasterTranslation.objects.create(
+            text="Hello",
+            plural_text={"h": "Helloes"},
+            hint="World!",
+            language_code="en"
+        )
+        translation = Translation.objects.get()
+
+        self.assertEqual(unicode(mt), "Hello (en plural)")
+
     def test_clean(self):
         MasterTranslation.objects.create(text="Buttons!")
         translation = Translation.objects.get()


### PR DESCRIPTION
Makes the admin view slightly more useful! Also added tests for `__unicode__` on both Translation and
MasterTranslation

I'm very unsure about my pluralness detection code in `Translation.__unicode__` - not sure I've properly understood how plural indices work.