### PR TITLE
Implement a better widget for translatable fields

### DIFF
--- a/fluent/fields.py
+++ b/fluent/fields.py
@@ -5,7 +5,7 @@ from django.db import IntegrityError
 from django import forms
 
 from .models import MasterTranslation
-from . import widgets
+from .forms import widgets
 
 
 class TranslatableContent(object):

--- a/fluent/fields.py
+++ b/fluent/fields.py
@@ -5,6 +5,7 @@ from django.db import IntegrityError
 from django import forms
 
 from .models import MasterTranslation
+from . import widgets
 
 
 class TranslatableContent(object):
@@ -22,7 +23,7 @@ class TranslatableContent(object):
         self._master_translation_cache = None
         self._text = text
         self._hint = hint
-        self._language_code = None if master_translation_id else settings.LANGUAGE_CODE
+        self._language_code = None if master_translation_id else (language_code or settings.LANGUAGE_CODE)
 
     @property
     def is_effectively_null(self):
@@ -137,7 +138,7 @@ class TranslatableCharField(models.ForeignKey):
         from fluent.forms import TranslatableCharField
         defaults = {
             'form_class': TranslatableCharField,
-            'hint': self.hint
+            'hint': self.hint,
         }
         defaults.update(kwargs)
 

--- a/fluent/forms/__init__.py
+++ b/fluent/forms/__init__.py
@@ -1,2 +1,23 @@
 
 from .fields import TranslatableCharField
+from . import widgets
+
+
+class ModelAdminMixin(object):
+    def __init__(self, *args, **kwargs):
+        from .. import fields
+
+        super(ModelAdminMixin, self).__init__(*args, **kwargs)
+        self.formfield_overrides[fields.TranslatableCharField] = { 'form_class': TranslatableCharField }
+        self.formfield_overrides[fields.TranslatableTextField] = {
+            'form_class': TranslatableCharField,
+            'widget': widgets.TranslatableTextField
+        }
+
+    def formfield_for_dbfield(self, db_field, **kwargs):
+        ret = super(ModelAdminMixin, self).formfield_for_dbfield(db_field, **kwargs)
+        if isinstance(ret, TranslatableCharField):
+            ret.widget.can_add_related = False
+            ret.widget.can_change_related = False
+            ret.widget.can_delete_related = False
+        return ret

--- a/fluent/forms/fields.py
+++ b/fluent/forms/fields.py
@@ -2,6 +2,8 @@ from django import forms
 from django.conf import settings
 
 from fluent.fields import TranslatableContent
+from . import widgets
+from .. import fields
 
 
 class TranslatableCharField(forms.CharField):
@@ -11,11 +13,21 @@ class TranslatableCharField(forms.CharField):
     def __init__(self, language_code=None, hint=u"", *args, **kwargs):
         self.language_code = language_code or settings.LANGUAGE_CODE
         self.hint = hint
+        kwargs.setdefault("widget", widgets.TranslatableCharField())
         super(TranslatableCharField, self).__init__(*args, **kwargs)
 
     def clean(self, value):
-        value = super(TranslatableCharField, self).clean(value)
-        if value:
+        if isinstance(value, TranslatableContent):
+            value.text = super(TranslatableCharField, self).clean(value.text)
+
+            if not value.hint:
+                value.hint = self.hint
+            if not value.language_code:
+                value.language_code = self.language_code
+            return value
+        elif isinstance(value, basestring):
+            value = super(TranslatableCharField, self).clean(value)
+
             return TranslatableContent(
                 text=value,
                 hint=self.hint,

--- a/fluent/forms/fields.py
+++ b/fluent/forms/fields.py
@@ -1,9 +1,7 @@
 from django import forms
 from django.conf import settings
 
-from fluent.fields import TranslatableContent
 from . import widgets
-from .. import fields
 
 
 class TranslatableCharField(forms.CharField):
@@ -17,6 +15,8 @@ class TranslatableCharField(forms.CharField):
         super(TranslatableCharField, self).__init__(*args, **kwargs)
 
     def clean(self, value):
+        from fluent.fields import TranslatableContent
+
         if isinstance(value, TranslatableContent):
             value.text = super(TranslatableCharField, self).clean(value.text)
 

--- a/fluent/forms/widgets.py
+++ b/fluent/forms/widgets.py
@@ -1,0 +1,48 @@
+from django.conf import settings
+from django.forms.widgets import (
+    MultiWidget,
+    TextInput,
+    Textarea,
+    Select
+)
+
+from fluent.fields import TranslatableContent
+
+
+class TranslatableWidget(MultiWidget):
+    """
+        A split widget which allows entering text for a master translation
+        and the language code that the text is in.
+    """
+    def decompress(self, value):
+        return value.text, value.language_code
+
+    def value_from_datadict(self, data, files, name):
+        text, language_code = [
+            widget.value_from_datadict(data, files, name + '_%s' % i)
+            for i, widget in enumerate(self.widgets)
+        ]
+        return TranslatableContent(text=text, language_code=language_code)
+
+
+class TranslatableCharField(TranslatableWidget):
+    #HACK! Django assumes that because it's a ForeignKey, that it has choices :(
+    choices = tuple()
+
+    def __init__(self, attrs=None, *args, **kwargs):
+        widgets = (
+            TextInput(attrs),
+            Select(attrs, choices=settings.LANGUAGES)
+        )
+        super(TranslatableCharField, self).__init__(widgets, attrs)
+
+
+class TranslatableTextField(TranslatableWidget):
+    choices = tuple()
+
+    def __init__(self, attrs=None, *args, **kwargs):
+        widgets = (
+            Textarea(attrs),
+            Select(attrs, choices=settings.LANGUAGES)
+        )
+        super(TranslatableTextField, self).__init__(widgets, attrs)

--- a/fluent/forms/widgets.py
+++ b/fluent/forms/widgets.py
@@ -13,7 +13,10 @@ class TranslatableWidget(MultiWidget):
         and the language code that the text is in.
     """
     def decompress(self, value):
-        return value.text, value.language_code
+        if value:
+            return value.text, value.language_code
+        else:
+            return u"", settings.LANGUAGE_CODE
 
     def value_from_datadict(self, data, files, name):
         from fluent.fields import TranslatableContent

--- a/fluent/forms/widgets.py
+++ b/fluent/forms/widgets.py
@@ -6,8 +6,6 @@ from django.forms.widgets import (
     Select
 )
 
-from fluent.fields import TranslatableContent
-
 
 class TranslatableWidget(MultiWidget):
     """
@@ -18,6 +16,8 @@ class TranslatableWidget(MultiWidget):
         return value.text, value.language_code
 
     def value_from_datadict(self, data, files, name):
+        from fluent.fields import TranslatableContent
+
         text, language_code = [
             widget.value_from_datadict(data, files, name + '_%s' % i)
             for i, widget in enumerate(self.widgets)


### PR DESCRIPTION
This commit adds widgets.TranslatableCharField and widgets.TranslatableTextField
which are MultiWidgets which allow entering text, as well as a language code. This is then
the default widget for forms.TranslatableCharField if no other widget (e.g. TextInput)
is specified. It also adds a ModelAdminMixin which you must use to enable these form fields
on the admin, because the admin is stupid and doesn't use the stuff returned from formfield().

If you use a TextInput widget, the language code comes from the one set on the form field or
settings.LANGUAGE_CODE.

Note! This commit means if you are display translatable fields on forms, you might want to override
the widget to be a TextInput to keep everything working the same.