### PR TITLE
Makes fluent Django 1.9 compatible

### DIFF
--- a/fluent/cldr/__init__.py
+++ b/fluent/cldr/__init__.py
@@ -69,7 +69,7 @@ Using that we can match indexed ordered forms to codenamed cldr forms allowing f
 """
 import re
 from decimal import Decimal, InvalidOperation
-from collections import OrderedDict as SortedDict
+from collections import OrderedDict
 
 from fluent.cldr.rules import LANGUAGE_LOOKUPS, get_plural_index
 
@@ -77,7 +77,7 @@ from fluent.cldr.rules import LANGUAGE_LOOKUPS, get_plural_index
 # Trying to keep the the data small
 _json_kw = ZERO, ONE, TWO, FEW, MANY, OTHER = 'zotfmh'
 _icu_kw = 'zero', 'one', 'two', 'few', 'many', 'other'
-ICU_KEYWORDS = SortedDict(zip(_icu_kw, _json_kw))
+ICU_KEYWORDS = OrderedDict(zip(_icu_kw, _json_kw))
 
 
 #RE_FORMAT_SYMBOLS = re.compile(r'(?<!%)(?:%%)*%s')

--- a/fluent/importexport.py
+++ b/fluent/importexport.py
@@ -6,7 +6,7 @@ import polib
 from django.conf import settings
 from django.http import HttpResponse
 from django.utils import timezone
-from django.utils.datastructures import SortedDict
+from collections import OrderedDict as SortedDict
 
 #FLUENT
 from .models import MasterTranslation, Translation

--- a/fluent/importexport.py
+++ b/fluent/importexport.py
@@ -6,7 +6,7 @@ import polib
 from django.conf import settings
 from django.http import HttpResponse
 from django.utils import timezone
-from collections import OrderedDict as SortedDict
+from collections import OrderedDict
 
 #FLUENT
 from .models import MasterTranslation, Translation
@@ -18,7 +18,7 @@ def export_translations_as_arb(masters):
     response = HttpResponse(content_type="application/arb")
     response['Content-Disposition'] = 'attachment; filename="translations.arb"'
 
-    data = SortedDict()
+    data = OrderedDict()
     data["@@locale"] = settings.LANGUAGE_CODE
     data["@@last_modified"] = timezone.now().strftime("%Y-%m-%dT%H:%M") + str.format('{0:+06.2f}', float(time.timezone) / 3600)
 


### PR DESCRIPTION
Was using the old `SortedDict`