### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/fluent/cldr/__init__.py
+++ b/fluent/cldr/__init__.py
@@ -61,7 +61,7 @@ We're keeping the internal representation closer to the cldr rules because they'
 (explicit ONE, ZERO, FEW, MANY) forms. Gettext uses a simpler approach with an indexed list of forms and a simple
 function for computing the index. There might be some convention to the order of plural forms for languages,
 so instead of generating the indexed form from our representation we manually match a Gettext
-plural form definition from here http://localization-guide.readthedocs.org/en/latest/l10n/pluralforms.html
+plural form definition from here https://localization-guide.readthedocs.io/en/latest/l10n/pluralforms.html
 to our cldr functions.
 
 Using that we can match indexed ordered forms to codenamed cldr forms allowing for *.po import and export.

--- a/fluent/cldr/rules.py
+++ b/fluent/cldr/rules.py
@@ -4,7 +4,7 @@
     We have language rules in a handy `plurls.xml` but until someone takes a weekend on a fun project writing a proper
     parser for those rules, we simply type them out by hand.
 
-    Gettext rules copied from: http://localization-guide.readthedocs.org/en/latest/l10n/pluralforms.html
+    Gettext rules copied from: https://localization-guide.readthedocs.io/en/latest/l10n/pluralforms.html
 
     We also manually assign a gettext plural-form for each language. We could in theory generate them from our more complex cldr rules,
     but it looks like gettext only cares for the value, disregarding fractions, decimal digits, etc.


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.