### PR TITLE
Fix `group` for blocktrans and add `group` for gettext

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ Then add `'fluent'` to `settings.INSTALLED_APPS`.
     `{% blocktrans group "rarely-used" %}Arm the detonator{% endblocktrans %}`.
 * Mark the translatable strings in your Python files in the normal way using
   `django.utils.translation.gettext` and friends.
-  - As with the templates, you should be able to optionally specify a `group` for each of these,
-    but that functionality isn't written yet (but it shouldn't be hard!).
+  - As with the templates, you can optionally specify a `group` for each of these like that:
+  `_('String', group='public')`
 * In the Django admin, go to the _Fluent_ app and hit the _Start Scan_ button to start a background
   task that will scan your files for translatable text.
 * You can also (or instead!) allow translatable text to be defined in values on models using

--- a/fluent/scanner.py
+++ b/fluent/scanner.py
@@ -36,6 +36,7 @@ def parse_file(content, extension):
         r"""\b(_|pgettext_lazy|gettext|pgettext|ugettext|ugettext_lazy)\(\s*"""
         r"""(?P<text>(?:".[^"]*?")|(?:'.[^']*?'))"""
         r"""(\s*,\s*(?P<hint>(?:".[^"]*?")|(?:'.[^']*?')))?"""
+        r"""(\s*,\s*group\s*=\s*(?P<group>(?:".[^"]*?")|(?:'.[^']*?')))?"""
         r"""\s*\)"""
     ]
 
@@ -43,8 +44,9 @@ def parse_file(content, extension):
         r"""\b(_|npgettext_lazy|ngettext|npgettext|ungettext|ungettext_lazy)\(\s*"""
         r"""(?P<text>(?:".[^"]*?")|(?:'.[^']*?'))"""
         r"""(\s*,\s*(?P<plural>(?:".[^"]*?")|(?:'.[^']*?')))"""
-        r"""(\s*,\s*(?P<count>(?:[^,)]*)))"""
+        r"""(\s*,\s*(?P<count>\d+))"""
         r"""(\s*,\s*(?P<hint>(?:".[^"]*?")|(?:'.[^']*?')))?"""
+        r"""(\s*,\s*group\s*=\s*(?P<group>(?:".[^"]*?")|(?:'.[^']*?')))?"""
         r"""\s*\)"""
     ]
 
@@ -179,9 +181,14 @@ def parse_file(content, extension):
                     hint = match.group('hint') or u""
                 except IndexError:
                     hint = u""
+                    
+                try:
+                    group = _strip_quotes(match.group('group')) or DEFAULT_TRANSLATION_GROUP
+                except IndexError:
+                    group = DEFAULT_TRANSLATION_GROUP
 
                 hint = _strip_quotes(hint)
-                results.append((text, "", hint, DEFAULT_TRANSLATION_GROUP))
+                results.append((text, "", hint, group))
 
         for regex in NREGEXES:
             result = re.compile(regex).finditer(content)
@@ -193,9 +200,14 @@ def parse_file(content, extension):
                     hint = match.group('hint') or u""
                 except IndexError:
                     hint = u""
+                    
+                try:
+                    group = _strip_quotes(match.group('group')) or DEFAULT_TRANSLATION_GROUP
+                except IndexError:
+                    group = DEFAULT_TRANSLATION_GROUP
 
                 hint = _strip_quotes(hint)
-                results.append((text, plural, hint, DEFAULT_TRANSLATION_GROUP))
+                results.append((text, plural, hint, group))
 
         return results
 

--- a/fluent/scanner.py
+++ b/fluent/scanner.py
@@ -64,11 +64,10 @@ def parse_file(content, extension):
         buf = []
         plural_buf = []
         in_plural = False
-
+        group = DEFAULT_TRANSLATION_GROUP
         context = None
 
         for i, (token_type, token) in enumerate(tokens):
-            group = DEFAULT_TRANSLATION_GROUP
             parts = list(smart_split(token))
 
             if "endblocktrans" in parts:
@@ -83,6 +82,7 @@ def parse_file(content, extension):
                 plural_buf = []
                 in_plural = False
                 context = ""
+                group = DEFAULT_TRANSLATION_GROUP
 
             elif "blocktrans" in parts:
                 start_tag = token

--- a/fluent/tests/test_scanner.py
+++ b/fluent/tests/test_scanner.py
@@ -1,0 +1,30 @@
+from djangae.test import TestCase
+
+from fluent.scanner import parse_file, DEFAULT_TRANSLATION_GROUP
+
+
+TEST_CONTENT = """{% trans "Test trans string with group" group "public" %}
+{% trans "Test trans string without group" %}
+Regular string
+{% blocktrans group "public" %}
+Test trans block with group
+{% endblocktrans %}
+{% blocktrans %}
+Test trans block without group
+{% endblocktrans %}"""
+
+
+class ScannerTests(TestCase):
+
+    def setUp(self):
+        pass
+
+    def test_basic_html_parsing(self):
+        results = parse_file(TEST_CONTENT, ".html")
+        expected = [
+            ('Test trans string with group', '', '', 'public'),
+            ('Test trans string without group', '', '', DEFAULT_TRANSLATION_GROUP),
+            ('\nTest trans block with group\n', '', '', 'public'),
+            ('\nTest trans block without group\n', '', '', DEFAULT_TRANSLATION_GROUP),
+        ]
+        self.assertEqual(results, expected)

--- a/fluent/tests/test_scanner.py
+++ b/fluent/tests/test_scanner.py
@@ -3,7 +3,7 @@ from djangae.test import TestCase
 from fluent.scanner import parse_file, DEFAULT_TRANSLATION_GROUP
 
 
-TEST_CONTENT = """{% trans "Test trans string with group" group "public" %}
+TEST_HTML_CONTENT = """{% trans "Test trans string with group" group "public" %}
 {% trans "Test trans string without group" %}
 Regular string
 {% blocktrans group "public" %}
@@ -13,6 +13,11 @@ Test trans block with group
 Test trans block without group
 {% endblocktrans %}"""
 
+TEST_PYTHON_CONTENT = """_('Test string')
+_('Test string with hint', 'hint')
+_('Test string with group', group='public')
+_('Test string with hint and group', 'hint', group='public')
+_('Plural string with hint and group', 'plural', 2, 'hint', group='public')"""
 
 class ScannerTests(TestCase):
 
@@ -20,11 +25,23 @@ class ScannerTests(TestCase):
         pass
 
     def test_basic_html_parsing(self):
-        results = parse_file(TEST_CONTENT, ".html")
+        results = parse_file(TEST_HTML_CONTENT, ".html")
         expected = [
             ('Test trans string with group', '', '', 'public'),
             ('Test trans string without group', '', '', DEFAULT_TRANSLATION_GROUP),
             ('\nTest trans block with group\n', '', '', 'public'),
             ('\nTest trans block without group\n', '', '', DEFAULT_TRANSLATION_GROUP),
         ]
+        self.assertEqual(results, expected)
+
+    def test_basic_python_parsing(self):
+        results = parse_file(TEST_PYTHON_CONTENT, ".py")
+        expected = [
+            ('Test string', '', '', DEFAULT_TRANSLATION_GROUP),
+            ('Test string with hint', '', 'hint', DEFAULT_TRANSLATION_GROUP),
+            ('Test string with group', '', '', 'public'),
+            ('Test string with hint and group', '', 'hint', 'public'),
+            ('Plural string with hint and group', 'plural', 'hint', 'public'),
+        ]
+        import pdb; pdb.set_trace()
         self.assertEqual(results, expected)

--- a/fluent/tests/test_scanner.py
+++ b/fluent/tests/test_scanner.py
@@ -43,5 +43,4 @@ class ScannerTests(TestCase):
             ('Test string with hint and group', '', 'hint', 'public'),
             ('Plural string with hint and group', 'plural', 'hint', 'public'),
         ]
-        import pdb; pdb.set_trace()
         self.assertEqual(results, expected)

--- a/fluent/trans.py
+++ b/fluent/trans.py
@@ -168,29 +168,29 @@ def _get_trans(text, hint, count=1, language_override=None):
     return forms[singular_index]
 
 
-def gettext(message):
+def gettext(message, group=None):
     return _get_trans(message, hint="").encode("utf-8")
 
 
-def ugettext(message):
+def ugettext(message, group=None):
     from django.utils.encoding import force_unicode
     return force_unicode(_get_trans(message, hint="", count=1))
 
 
-def pgettext(context, message):
+def pgettext(context, message, group=None):
     return _get_trans(message, hint=context)
 
 
-def ungettext(singular, plural, number):
+def ungettext(singular, plural, number, group=None):
     from django.utils.encoding import force_unicode
     return force_unicode(_get_trans(singular, hint="", count=number))
 
 
-def ngettext(singular, plural, number):
+def ngettext(singular, plural, number, group=None):
     return _get_trans(singular, hint="", count=number).encode("utf-8")
 
 
-def npgettext(context, singular, plural, number):
+def npgettext(context, singular, plural, number, group=None):
     return _get_trans(singular, context, number)
 
 


### PR DESCRIPTION
Because we would reset group variable when we loop through the tokens, the group from {% blocktrans %} tag would be overwritten before we get to the end of that block.