### PR TITLE
Escape trans and blocktrans tags by default unless 'noescape' is passed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.egg-info
 fluent/.storage
 /libs
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ Then add `'fluent'` to `settings.INSTALLED_APPS`.
   field whose value is the "original" (default) text, which can then be translated.
 * You can then use the exporting functionality (TODO!) to export files containing the translation
   definitions, and you can then imported the translated texts (also TODO).
+* __NOTE__: The fluent trans and blocktrans tags will escape by default unlike the Django counterparts (see https://code.djangoproject.com/ticket/25872)
+ if you do not want your translations escaped, you can pass "noescape" as an argument to the trans tag or opening blocktrans. This is done for security as
+ translations are stored in the database and so could potentially be malliciously altered.
 
 
 

--- a/fluent/patches.py
+++ b/fluent/patches.py
@@ -21,12 +21,12 @@ from .trans import (
 
 try:
     #Define a generator if model_mommy is available
-    from model_mommy import generators
+    from model_mommy import random_gen
 
     mommy_available = True
     def gen_translatablecontent():
         from fluent.fields import TranslatableContent
-        return TranslatableContent(text=generators.gen_text())
+        return TranslatableContent(text=random_gen.gen_text())
 except ImportError:
     mommy_available = False
 

--- a/fluent/scanner.py
+++ b/fluent/scanner.py
@@ -29,6 +29,7 @@ def parse_file(content, extension):
         r"""(\s+context\s+(?P<hint>(?:".[^"]*?")|(?:'.[^']*?')))?""" #The context of the translation
         r"""(\s+as\s+\w+)?""" # Any alias e.g. as banana
         r"""(\s+group\s+(?P<group>(?:".[^"]*?")|(?:'.[^']*?')))?"""
+        r"""(\s+noescape)?""" # Noescape filter
         r"""\s*%\}""", # {% trans "things" as stuff%}
     ]
 

--- a/fluent/scanner.py
+++ b/fluent/scanner.py
@@ -72,7 +72,7 @@ def parse_file(content, extension):
         for i, (token_type, token) in enumerate(tokens):
             parts = list(smart_split(token))
 
-            if "endblocktrans" in parts:
+            if "{%endblocktrans" in token.replace(" ", ""):
                 buf_joined = "".join(buf)
                 plural_buf_joined = "".join(plural_buf)
                 if "trimmed" in list(smart_split(start_tag)):
@@ -86,7 +86,7 @@ def parse_file(content, extension):
                 context = ""
                 group = DEFAULT_TRANSLATION_GROUP
 
-            elif "blocktrans" in parts:
+            elif "{%blocktrans" in token.replace(" ", ""):
                 start_tag = token
 
                 try:

--- a/fluent/tests/test_plurals.py
+++ b/fluent/tests/test_plurals.py
@@ -64,6 +64,9 @@ class TestPluralRules(TestCase):
                 data[cldr.ICU_KEYWORDS[rule.attrib['count']]] = set(example_values)
             cls.examples.append(data)
 
+    def tearDown(self):
+        translation.deactivate()
+
     def test_plural_rules(self):
         """ Test all example values from plurals.xml against our pluralization rules."""
         for example in self.examples:

--- a/fluent/tests/test_scanner.py
+++ b/fluent/tests/test_scanner.py
@@ -3,6 +3,7 @@ from django.template import Template, Context
 
 from fluent.scanner import parse_file, DEFAULT_TRANSLATION_GROUP
 from fluent.models import MasterTranslation
+from fluent.trans import TRANSLATION_CACHE
 
 
 TEST_HTML_CONTENT = """{% load fluent %}
@@ -35,7 +36,7 @@ _('Plural string with hint and group', 'plural', 2, 'hint', group='public')"""
 class ScannerTests(TestCase):
 
     def setUp(self):
-        pass
+        TRANSLATION_CACHE.invalidate()
 
     def test_basic_html_parsing(self):
         results = parse_file(TEST_HTML_CONTENT, ".html")

--- a/fluent/tests/test_scanner.py
+++ b/fluent/tests/test_scanner.py
@@ -1,23 +1,35 @@
 from djangae.test import TestCase
+from django.template import Template, Context
 
 from fluent.scanner import parse_file, DEFAULT_TRANSLATION_GROUP
 
 
-TEST_HTML_CONTENT = """{% trans "Test trans string with group" group "public" %}
+TEST_HTML_CONTENT = """{% load fluent %}
+{% trans "Test trans string with group" group "public" %}
 {% trans "Test trans string without group" %}
+{% trans "Test & escaping" %}
+{% trans "Test & unescaping" noescape %}
 Regular string
 {% blocktrans group "public" %}
 Test trans block with group
 {% endblocktrans %}
 {% blocktrans %}
 Test trans block without group
-{% endblocktrans %}"""
+{% endblocktrans %}
+{% blocktrans %}
+Test blocktrans & escaping
+{% endblocktrans %}
+{% blocktrans noescape %}
+Test blocktrans & unescaping
+{% endblocktrans %}
+"""
 
 TEST_PYTHON_CONTENT = """_('Test string')
 _('Test string with hint', 'hint')
 _('Test string with group', group='public')
 _('Test string with hint and group', 'hint', group='public')
 _('Plural string with hint and group', 'plural', 2, 'hint', group='public')"""
+
 
 class ScannerTests(TestCase):
 
@@ -29,8 +41,11 @@ class ScannerTests(TestCase):
         expected = [
             ('Test trans string with group', '', '', 'public'),
             ('Test trans string without group', '', '', DEFAULT_TRANSLATION_GROUP),
+            ('Test & escaping', '', '', DEFAULT_TRANSLATION_GROUP),
             ('\nTest trans block with group\n', '', '', 'public'),
             ('\nTest trans block without group\n', '', '', DEFAULT_TRANSLATION_GROUP),
+            ('\nTest blocktrans & escaping\n', '', '', DEFAULT_TRANSLATION_GROUP),
+            ('\nTest blocktrans & unescaping\n', '', '', DEFAULT_TRANSLATION_GROUP),
         ]
         self.assertEqual(results, expected)
 
@@ -44,3 +59,11 @@ class ScannerTests(TestCase):
             ('Plural string with hint and group', 'plural', 'hint', 'public'),
         ]
         self.assertEqual(results, expected)
+
+    def test_render_and_escaping(self):
+        rendered = Template(TEST_HTML_CONTENT).render(Context({}))
+        self.assertTrue("Test &amp; escaping" in rendered)
+        self.assertTrue("Test & unescaping" in rendered)
+        self.assertTrue("Test trans block with group" in rendered)
+        self.assertTrue("Test blocktrans &amp; escaping" in rendered)
+        self.assertTrue("Test blocktrans & unescaping" in rendered)

--- a/fluent/tests/test_scanner.py
+++ b/fluent/tests/test_scanner.py
@@ -2,6 +2,7 @@ from djangae.test import TestCase
 from django.template import Template, Context
 
 from fluent.scanner import parse_file, DEFAULT_TRANSLATION_GROUP
+from fluent.models import MasterTranslation
 
 
 TEST_HTML_CONTENT = """{% load fluent %}
@@ -21,18 +22,6 @@ Test blocktrans & escaping
 {% endblocktrans %}
 {% blocktrans noescape %}
 Test blocktrans & unescaping
-{% endblocktrans %}
-{% blocktrans %}
-<a href="http://google.com">{{ name }}</a> without group
-{% endblocktrans %}
-{% blocktrans noescape %}
-<a href="http://google.com">{{ name }}</a> without group
-{% endblocktrans %}
-{% blocktrans group "public" %}
-<a href="http://google.com">{{ name }}</a> in group
-{% endblocktrans %}
-{% blocktrans noescape group "public" %}
-<a href="http://google.com">{{ name }}</a> in group
 {% endblocktrans %}
 """
 
@@ -54,16 +43,302 @@ class ScannerTests(TestCase):
             ('Test trans string with group', '', '', 'public'),
             ('Test trans string without group', '', '', DEFAULT_TRANSLATION_GROUP),
             ('Test & escaping', '', '', DEFAULT_TRANSLATION_GROUP),
+            ('Test & unescaping', '', '', DEFAULT_TRANSLATION_GROUP),
             ('\nTest trans block with group\n', '', '', 'public'),
             ('\nTest trans block without group\n', '', '', DEFAULT_TRANSLATION_GROUP),
             ('\nTest blocktrans & escaping\n', '', '', DEFAULT_TRANSLATION_GROUP),
             ('\nTest blocktrans & unescaping\n', '', '', DEFAULT_TRANSLATION_GROUP),
-            ('\n<a href="http://google.com">%(name)s</a> without group\n', '', '', DEFAULT_TRANSLATION_GROUP),
-            ('\n<a href="http://google.com">%(name)s</a> without group\n', '', '', DEFAULT_TRANSLATION_GROUP),
-            ('\n<a href="http://google.com">%(name)s</a> in group\n', '', '', 'public'),
-            ('\n<a href="http://google.com">%(name)s</a> in group\n', '', '', 'public'),
         ]
         self.assertEqual(results, expected)
+
+    def test_trans_tag_with_group(self):
+        text = "Test trans string with group"
+        content = """
+{% load fluent %}
+{% trans "Test trans string with group" group "public" %}
+        """
+        results = parse_file(content, ".html")
+        expected = [
+            (text, '', '', 'public'),
+        ]
+        self.assertEqual(results, expected)
+        rendered = Template(content).render(Context())
+        self.assertTrue("Test trans string with group" in rendered)
+
+        # create master translation for the string and test it renders correctly
+        key = MasterTranslation.generate_key(text, '', 'en-us')
+        mt = MasterTranslation.objects.create(
+            pk=key, text=text, language_code='en-us'
+        )
+        mt.used_by_groups_in_code_or_templates = {'public'}
+        mt.save()
+
+        rendered = Template(content).render(Context())
+        self.assertTrue("Test trans string with group" in rendered)
+
+    def test_trans_tag_without_group(self):
+        text = "Test trans string without group"
+        content = """
+{% load fluent %}
+{% trans "Test trans string without group" %}
+        """
+        results = parse_file(content, ".html")
+        expected = [(text, '', '', DEFAULT_TRANSLATION_GROUP)]
+        self.assertEqual(results, expected)
+
+        rendered = Template(content).render(Context())
+        self.assertTrue(text in rendered)
+
+        # create master translation for the string and test it renders correctly
+        key = MasterTranslation.generate_key(text, '', 'en-us')
+        MasterTranslation.objects.create(
+            pk=key, text=text, language_code='en-us'
+        )
+        rendered = Template(content).render(Context())
+        self.assertTrue("Test trans string without group" in rendered)
+
+    def test_trans_tag_and_escaping(self):
+        text = "Test & escaping"
+        content = """
+{% load fluent %}
+{% trans "Test & escaping" %}
+        """
+        results = parse_file(content, ".html")
+        expected = [
+            (text, '', '', DEFAULT_TRANSLATION_GROUP),
+        ]
+        self.assertEqual(results, expected)
+        rendered = Template(content).render(Context())
+        self.assertTrue("Test &amp; escaping" in rendered)
+
+        # create master translation for the string and test it renders correctly
+        key = MasterTranslation.generate_key(text, '', 'en-us')
+        MasterTranslation.objects.create(
+            pk=key, text=text, language_code='en-us'
+        )
+        rendered = Template(content).render(Context())
+        self.assertTrue("Test &amp; escaping" in rendered)
+
+    def test_trans_tag_and_noescape(self):
+        text = "Test & unescaping"
+        content = """
+{% load fluent %}
+{% trans "Test & unescaping" noescape %}
+        """
+        results = parse_file(content, ".html")
+        expected = [(text, '', '', DEFAULT_TRANSLATION_GROUP)]
+        self.assertEqual(results, expected)
+
+        rendered = Template(content).render(Context())
+        self.assertTrue(text in rendered)
+
+        # create master translation for the string and test it renders correctly
+        key = MasterTranslation.generate_key(text, '', 'en-us')
+        MasterTranslation.objects.create(
+            pk=key, text=text, language_code='en-us'
+        )
+        rendered = Template(content).render(Context())
+        self.assertTrue("Test & unescaping" in rendered)
+
+    def test_blocktrans_tag_with_group(self):
+        text = "\nTest trans block with group\n"
+        content = """
+{% load fluent %}
+{% blocktrans group "public" %}
+Test trans block with group
+{% endblocktrans %}
+        """
+        results = parse_file(content, ".html")
+        expected = [
+            (text, '', '', 'public'),
+        ]
+        self.assertEqual(results, expected)
+        rendered = Template(content).render(Context())
+        self.assertTrue(text in rendered)
+
+        # create master translation for the string and test it renders correctly
+        key = MasterTranslation.generate_key(text, '', 'en-us')
+        mt = MasterTranslation.objects.create(
+            pk=key, text=text, language_code='en-us'
+        )
+        mt.used_by_groups_in_code_or_templates = {'public'}
+        mt.save()
+
+        rendered = Template(content).render(Context())
+        self.assertTrue("Test trans block with group" in rendered)
+
+    def test_blocktrans_tag_without_group(self):
+        text = "\nTest trans block without group\n"
+        content = """
+{% load fluent %}
+{% blocktrans %}
+Test trans block without group
+{% endblocktrans %}
+        """
+        results = parse_file(content, ".html")
+        expected = [(text, '', '', DEFAULT_TRANSLATION_GROUP)]
+        self.assertEqual(results, expected)
+
+        rendered = Template(content).render(Context())
+        self.assertTrue(text in rendered)
+
+        # create master translation for the string and test it renders correctly
+        key = MasterTranslation.generate_key(text, '', 'en-us')
+        MasterTranslation.objects.create(
+            pk=key, text=text, language_code='en-us'
+        )
+        rendered = Template(content).render(Context())
+        self.assertTrue("Test trans block without group" in rendered)
+
+    def test_blocktrans_tag_and_escaping(self):
+        text = "\nTest blocktrans & escaping\n"
+        content = """
+{% load fluent %}
+{% blocktrans %}
+Test blocktrans & escaping
+{% endblocktrans %}
+        """
+        results = parse_file(content, ".html")
+        expected = [
+            (text, '', '', DEFAULT_TRANSLATION_GROUP),
+        ]
+        self.assertEqual(results, expected)
+        rendered = Template(content).render(Context())
+        self.assertTrue("Test blocktrans &amp; escaping" in rendered)
+
+        # create master translation for the string and test it renders correctly
+        key = MasterTranslation.generate_key(text, '', 'en-us')
+        MasterTranslation.objects.create(
+            pk=key, text=text, language_code='en-us'
+        )
+        rendered = Template(content).render(Context())
+        self.assertTrue("Test blocktrans &amp; escaping" in rendered)
+
+    def test_blocktrans_tag_and_noescape(self):
+        text = "\nTest blocktrans & unescaping\n"
+        content = """
+{% load fluent %}
+{% blocktrans noescape %}
+Test blocktrans & unescaping
+{% endblocktrans %}
+        """
+        results = parse_file(content, ".html")
+        expected = [(text, '', '', DEFAULT_TRANSLATION_GROUP)]
+        self.assertEqual(results, expected)
+
+        rendered = Template(content).render(Context())
+        self.assertTrue(text in rendered)
+
+        # create master translation for the string and test it renders correctly
+        key = MasterTranslation.generate_key(text, '', 'en-us')
+        MasterTranslation.objects.create(
+            pk=key, text=text, language_code='en-us'
+        )
+        rendered = Template(content).render(Context())
+        self.assertTrue("Test blocktrans & unescaping" in rendered)
+
+    def test_blocktrans_tag_with_variable_and_group_escaping(self):
+        text = '\n<a href="http://google.com">%(name)s</a> in group\n'
+        content = """
+{% load fluent %}
+{% blocktrans group "public" %}
+<a href="http://google.com">{{ name }}</a> in group
+{% endblocktrans %}
+        """
+        results = parse_file(content, ".html")
+        expected = [
+            (text, '', '', 'public'),
+        ]
+        self.assertEqual(results, expected)
+
+        data = {'name': "Ola & Ola"}
+        rendered = Template(content).render(Context(data))
+        self.assertTrue('&lt;a href=&quot;http://google.com&quot;&gt;Ola &amp; Ola&lt;/a&gt; in group' in rendered)
+
+        # create master translation for the string and test it renders correctly
+        key = MasterTranslation.generate_key(text, '', 'en-us')
+        mt = MasterTranslation.objects.create(
+            pk=key, text=text, language_code='en-us'
+        )
+        mt.used_by_groups_in_code_or_templates = {'public'}
+        mt.save()
+
+        rendered = Template(content).render(Context(data))
+        self.assertTrue('&lt;a href=&quot;http://google.com&quot;&gt;Ola &amp; Ola&lt;/a&gt; in group' in rendered)
+
+    def test_blocktrans_tag_with_variable_and_with_group_noescaping(self):
+        text = '\n<a href="http://google.com">%(name)s</a> in group\n'
+        content = """
+{% load fluent %}
+{% blocktrans noescape group "public" %}
+<a href="http://google.com">{{ name }}</a> in group
+{% endblocktrans %}
+        """
+        results = parse_file(content, ".html")
+        expected = [(text, '', '', 'public')]
+        self.assertEqual(results, expected)
+
+        data = {'name': "Ola & Ola"}
+        rendered = Template(content).render(Context(data))
+        self.assertTrue('<a href="http://google.com">Ola &amp; Ola</a> in group' in rendered)
+
+        # create master translation for the string and test it renders correctly
+        key = MasterTranslation.generate_key(text, '', 'en-us')
+        MasterTranslation.objects.create(
+            pk=key, text=text, language_code='en-us'
+        )
+        rendered = Template(content).render(Context(data))
+        self.assertTrue('<a href="http://google.com">Ola &amp; Ola</a> in group' in rendered)
+
+    def test_blocktrans_tag_with_variable_escaping(self):
+        text = '\n<a href="http://google.com">%(name)s</a> without group\n'
+        content = """
+{% load fluent %}
+{% blocktrans %}
+<a href="http://google.com">{{ name }}</a> without group
+{% endblocktrans %}
+        """
+        results = parse_file(content, ".html")
+        expected = [
+            (text, '', '', DEFAULT_TRANSLATION_GROUP),
+        ]
+        self.assertEqual(results, expected)
+
+        data = {'name': "Ola & Ola"}
+        rendered = Template(content).render(Context(data))
+        self.assertTrue('&lt;a href=&quot;http://google.com&quot;&gt;Ola &amp; Ola&lt;/a&gt; without group' in rendered)
+
+        # create master translation for the string and test it renders correctly
+        key = MasterTranslation.generate_key(text, '', 'en-us')
+        MasterTranslation.objects.create(
+            pk=key, text=text, language_code='en-us'
+        )
+        rendered = Template(content).render(Context(data))
+        self.assertTrue('&lt;a href=&quot;http://google.com&quot;&gt;Ola &amp; Ola&lt;/a&gt; without group' in rendered)
+
+    def test_blocktrans_tag_with_variable_and_noescaping(self):
+        text = '\n<a href="http://google.com">%(name)s</a> without group\n'
+        content = """
+{% load fluent %}
+{% blocktrans noescape %}
+<a href="http://google.com">{{ name }}</a> without group
+{% endblocktrans %}
+        """
+        results = parse_file(content, ".html")
+        expected = [(text, '', '', DEFAULT_TRANSLATION_GROUP)]
+        self.assertEqual(results, expected)
+
+        data = {'name': "Ola & Ola"}
+        rendered = Template(content).render(Context(data))
+        self.assertTrue('<a href="http://google.com">Ola &amp; Ola</a> without group' in rendered)
+
+        # create master translation for the string and test it renders correctly
+        key = MasterTranslation.generate_key(text, '', 'en-us')
+        MasterTranslation.objects.create(
+            pk=key, text=text, language_code='en-us'
+        )
+        rendered = Template(content).render(Context(data))
+        self.assertTrue('<a href="http://google.com">Ola &amp; Ola</a> without group' in rendered)
 
     def test_basic_python_parsing(self):
         results = parse_file(TEST_PYTHON_CONTENT, ".py")
@@ -83,11 +358,3 @@ class ScannerTests(TestCase):
         self.assertTrue("Test trans block with group" in rendered)
         self.assertTrue("Test blocktrans &amp; escaping" in rendered)
         self.assertTrue("Test blocktrans & unescaping" in rendered)
-
-        self.assertTrue('<a href="http://google.com">Ola &amp; Ola</a> in group' in rendered)
-        # even if blocktrans has "noescape" the & from variable is escaped
-        self.assertFalse('<a href="http://google.com">Ola & Ola</a> in group' in rendered)
-
-        self.assertTrue('<a href="http://google.com">Ola &amp; Ola</a> without group' in rendered)
-        # even if blocktrans has "noescape" the & from variable is escaped
-        self.assertFalse('<a href="http://google.com">Ola & Ola</a> without group' in rendered)

--- a/fluent/tests/test_trans.py
+++ b/fluent/tests/test_trans.py
@@ -16,6 +16,7 @@ from fluent.trans import (
 
 from fluent.models import MasterTranslation
 
+
 class TranslationTests(TestCase):
 
     def setUp(self):
@@ -35,6 +36,9 @@ class TranslationTests(TestCase):
         invalidate_language("en")
         invalidate_language("de")
         invalidate_language("es")
+
+    def tearDown(self):
+        translation.deactivate()
 
     def test_gettext(self):
         translation.activate("es")
@@ -71,7 +75,6 @@ class TranslationTests(TestCase):
             trans = gettext("Goodbye World!")
             self.assertEqual(trans, "Auf Wiedersehen Welt!")
             self.assertFalse(query.called)
-
 
     def test_memcache_invalidates_when_the_request_ends(self):
         translation.activate("de")

--- a/fluent/tests/test_trans.py
+++ b/fluent/tests/test_trans.py
@@ -11,7 +11,8 @@ from fluent.trans import (
     invalidate_language,
     translations_loading,
     _language_invalidation_key,
-    invalidate_caches_if_necessary
+    invalidate_caches_if_necessary,
+    TRANSLATION_CACHE,
 )
 
 from fluent.models import MasterTranslation
@@ -20,6 +21,7 @@ from fluent.models import MasterTranslation
 class TranslationTests(TestCase):
 
     def setUp(self):
+        TRANSLATION_CACHE.invalidate()
         self.mt = MasterTranslation.objects.create(
             text="Hello World!",
             language_code="en"

--- a/fluent/trans.py
+++ b/fluent/trans.py
@@ -156,8 +156,21 @@ def _get_trans(text, hint, count=1, language_override=None):
     forms = TRANSLATION_CACHE.get_translation(text, hint, language_code)
 
     if not forms:
-        logger.debug("Found string not translated into %s so falling back to default, string was %s", language_code, text)
-        return text
+        # We have no translation for this text.
+        logger.debug(
+            "Found string not translated into %s so falling back to default, string was %s",
+            language_code, text
+        )
+        # This unicode() call is important.  If we are here it means that we do not have a
+        # translation for this text string, so we want to just return the default text, which is
+        # the `text` variable. But if this variable has come from a `{% trans %}` tag, then it will
+        # have been through django.template.base.Variable.__init__, which makes the assumption that
+        # any string literal defined in a template is safe, and therefore it calls mark_safe() on
+        # it.  Fluent's `trans` tag deliberately does NOT make the assumption that string literals
+        # defined inside it are safe (because we don't want to send pre-escaped text to translators)
+        # and therefore we must remove the assumption that the string is safe. Calling unicode() on
+        # it turns it from a SafeText object back to a normal unicode object.
+        return unicode(text)
 
     plural_index = get_plural_index(language_code, count)
     # Fall back to singular form if the correct plural doesn't exist. This will happen until all languages have been re-uploaded.


### PR DESCRIPTION
This PR changes the `{% trans %}` and `{% blocktrans %}` tags so that they escape content while rendering by default. The strings which are stored in the datastore or exported/import remain unchanged but this prevents the possibility of someone maliciously uploading scripts as translations.

There is now an optional argument to both tags: "noescape" which will prevent escaping if your tags contain HTML. 
