### PR TITLE
Export for locale code

### DIFF
--- a/fluent/importexport.py
+++ b/fluent/importexport.py
@@ -205,7 +205,9 @@ def import_translations_from_po(file_contents, language_code, from_language):
 
 
 def export_translations_to_po(language_code):
-    lookup = LANGUAGE_LOOKUPS[language_code]
+    # Convert 'en-us' to 'en'. The pluralization rules don't cover full locales.
+    lang = language_code.split('-')[0].lower()
+    lookup = LANGUAGE_LOOKUPS[lang]
 
     pofile = polib.POFile()
     for master in MasterTranslation.objects.all():

--- a/fluent/tests/test_importexport.py
+++ b/fluent/tests/test_importexport.py
@@ -94,3 +94,21 @@ class ExportPOTestCase(TestCase):
         po_file = polib.pofile(unicode(
             export_translations_to_po('en').content.decode('utf-8')))
         self.assertEqual(EXPECTED_EXPORT_PO_FILE, po_file.__unicode__())
+
+    def test_export_handles_language_region_codes(self):
+        # Fluent should handle 'en-US' as a language code. Previously
+        # `export_translations_to_po('en-US')` would raise KeyError.
+
+        MasterTranslation(text=u'Foo', hint=u'Bar', language_code='en').save()
+
+        result = unicode(export_translations_to_po('en-US'))
+        expected = (
+            u'Content-Type: text/plain\r\n'
+            u'Content-Disposition: attachment; filename=django.po\r\n\r\n'
+            u'#. Bar\n'
+            u'msgctxt "Bar"\n'
+            u'msgid "Foo"\n'
+            u'msgstr "Foo"\n'
+        )
+
+        self.assertEqual(result, expected)


### PR DESCRIPTION
Hi,

These changes potentially fix #23 , by allowing `fluent.importexport.export_translations_to_po()` to be called with a full language code like "en-US". It just ignores the region part (if any).

Hope this helps,

David B.
