### PR TITLE
Added fluent.cldr.rules.get_rules_for_language function.

### DIFF
--- a/fluent/cldr/__init__.py
+++ b/fluent/cldr/__init__.py
@@ -71,7 +71,7 @@ import re
 from decimal import Decimal, InvalidOperation
 from collections import OrderedDict
 
-from fluent.cldr.rules import LANGUAGE_LOOKUPS, get_plural_index
+from fluent.cldr.rules import get_plural_index, get_rules_for_language
 
 
 # Trying to keep the the data small
@@ -135,7 +135,7 @@ def export_translation_message(trans, only_used=False):
     if not trans.plurals:
         return _icu_encode(trans.translated_text)
 
-    lookup_fun = LANGUAGE_LOOKUPS[trans.language_code.split("-")[0].lower()]
+    lookup_fun = get_rules_for_language(trans.language_code)
     if not trans.master.plural_text:
         singular_form = lookup_fun(1)
         return _icu_encode(trans.plurals[singular_form])

--- a/fluent/cldr/rules.py
+++ b/fluent/cldr/rules.py
@@ -352,8 +352,14 @@ def _default(value):
 
 
 def get_plural_index(language_code, value):
-    return LANGUAGE_LOOKUPS.get(language_code.split("-")[0].lower(), _default)(value)
+    lookup = get_rules_for_language(language_code)
+
+    return lookup(value)
 
 
+def get_rules_for_language(language_code):
+    # Convert 'en-us' to 'en'. The pluralization rules don't cover full locales.
+    lang = language_code.split('-')[0].lower()
+    lookup = LANGUAGE_LOOKUPS.get(lang, _default)
 
-
+    return lookup

--- a/fluent/importexport.py
+++ b/fluent/importexport.py
@@ -12,7 +12,7 @@ from collections import OrderedDict
 #FLUENT
 from .models import MasterTranslation, Translation
 from . import cldr
-from .cldr.rules import LANGUAGE_LOOKUPS, get_plural_index
+from .cldr.rules import get_plural_index, get_rules_for_language
 
 
 def export_translations_as_arb(masters, language_code=settings.LANGUAGE_CODE):
@@ -58,7 +58,7 @@ def export_translations_as_csv(masters, language_code=settings.LANGUAGE_CODE):
 
 
 def get_used_fields(plurals, language_code):
-    lookup = LANGUAGE_LOOKUPS[language_code]
+    lookup = get_rules_for_language(language_code)
     missing = set(lookup.plurals_used) - set(plurals)
     if missing:
         RK = dict((v, k) for (k, v) in cldr.ICU_KEYWORDS.items())
@@ -104,7 +104,7 @@ def import_translations_from_arb(file_in, language_code):
 
 def import_translations_from_csv(file_contents, language_code):
     reader = csv.DictReader(file_contents)
-    lookup = LANGUAGE_LOOKUPS[language_code]
+    lookup = get_rules_for_language(language_code)
     errors = []
 
     for row in reader:
@@ -168,7 +168,7 @@ def import_translations_from_po(file_contents, language_code, from_language):
     pofile = polib.pofile(file_contents, encoding='utf-8')
     errors = []
 
-    lookup = LANGUAGE_LOOKUPS[language_code]
+    lookup = get_rules_for_language(language_code)
 
     for entry in pofile:
         pk = MasterTranslation.generate_key(entry.msgid, entry.msgctxt or '', from_language)
@@ -205,9 +205,7 @@ def import_translations_from_po(file_contents, language_code, from_language):
 
 
 def export_translations_to_po(language_code):
-    # Convert 'en-us' to 'en'. The pluralization rules don't cover full locales.
-    lang = language_code.split('-')[0].lower()
-    lookup = LANGUAGE_LOOKUPS[lang]
+    lookup = get_rules_for_language(language_code)
 
     pofile = polib.POFile()
     for master in MasterTranslation.objects.all():

--- a/fluent/tests/test_cldr_rules.py
+++ b/fluent/tests/test_cldr_rules.py
@@ -1,0 +1,29 @@
+import unittest
+
+from fluent.cldr import rules
+
+
+class GetRulesForLanguageTestCase(unittest.TestCase):
+    def test_returns_plural_function_for_language_code(self):
+        result = rules.get_rules_for_language('en')
+
+        self.assertIn('en', rules.LANGUAGE_LOOKUPS)
+        self.assertEqual(result, rules.l_one_or_many_or_fraction)
+
+    def test_returns_default_for_unknown_language_code(self):
+        result = rules.get_rules_for_language('foo')
+
+        self.assertNotIn('foo', rules.LANGUAGE_LOOKUPS)
+        self.assertEqual(result, rules._default)
+
+    def test_handles_language_code_with_region(self):
+        result = rules.get_rules_for_language('en-us')
+
+        self.assertNotIn('en-us', rules.LANGUAGE_LOOKUPS)
+        self.assertEqual(result, rules.l_one_or_many_or_fraction)
+
+    def test_handles_upper_case_language_code(self):
+        result = rules.get_rules_for_language('EN')
+
+        self.assertNotIn('EN', rules.LANGUAGE_LOOKUPS)
+        self.assertEqual(result, rules.l_one_or_many_or_fraction)

--- a/fluent/tests/test_plurals.py
+++ b/fluent/tests/test_plurals.py
@@ -16,7 +16,7 @@ from django.utils import translation
 from fluent.models import MasterTranslation, Translation
 from fluent import cldr
 from fluent.trans import ngettext, gettext, invalidate_language
-from fluent.cldr.rules import get_plural_index  # dummy implementation just for tests
+from fluent.cldr.rules import LANGUAGE_LOOKUPS, get_plural_index  # dummy implementation just for tests
 from fluent.importexport import import_translations_from_arb, import_translations_from_po
 from fluent.cldr import expr_parser
 
@@ -30,7 +30,7 @@ class TestPluralRules(TestCase):
 
         #lang_dict = getattr(settings, "ALTERNATIVES_DICT", dict((x, x) for x, y in settings.LANGUAGES))
         # we don't have rules for those languages
-        SUPPORTED_LANGUAGES = cldr.LANGUAGE_LOOKUPS.keys()
+        SUPPORTED_LANGUAGES = LANGUAGE_LOOKUPS.keys()
 
         # Parse the xml and come up with a dict of example values:
         cls.examples = []


### PR DESCRIPTION
At the moment there are a few places in the code which fetch the pluralisation rules from the LANGUAGE_LOOKUPS dict, and they don't handle unknown languages or language codes with a region.

This provides a consistent way to lookup the pluralisation rules for a language code, taking care to handle 'en-us' and 'EN', etc. and return a default rule for unknown language codes.
