### PR TITLE
Fix `walk_dir` to pick up all `html` and `py` files.

### DIFF
--- a/fluent/scanner.py
+++ b/fluent/scanner.py
@@ -284,7 +284,7 @@ def begin_scan(marshall):
         for f in files:
             filename = os.path.normpath(os.path.join(root, f))
             if os.path.splitext(filename)[1] not in (".py", ".html"):
-                return
+                continue
 
             append_file(filename, files_to_scan)
 


### PR DESCRIPTION
* previously whenever we had any file with extension other than html or
py we immediatelly stopped running the function, which is not what we
want to do.
* now instead of stopping the function we simply jump to the next
iteration. This way we make sure we add all html and python files from
the given directory.