### PR TITLE
Fix find closest supported language

### DIFF
--- a/fluent/tests/test_models.py
+++ b/fluent/tests/test_models.py
@@ -1,6 +1,7 @@
 from djangae.test import TestCase
 from django.conf import settings
 from django.core.exceptions import ValidationError
+from django.test import override_settings
 
 from fluent.models import MasterTranslation, Translation
 
@@ -35,6 +36,7 @@ class MasterTranslationTests(TestCase):
         # Make sure that it differs
         self.assertNotEqual(mt1.pk, mt2.pk)
 
+    @override_settings(LANGUAGES=[("en", "English"), ("de", "German")])
     def test_text_for_language_code(self):
         mt = MasterTranslation.objects.create(text="Hello World!")
         text = mt.text_for_language_code("de")  # try to fetch an translation we don't have

--- a/fluent/tests/test_utils.py
+++ b/fluent/tests/test_utils.py
@@ -1,0 +1,33 @@
+# THIRD PARTY
+from djangae.test import TestCase
+from django.test import override_settings
+
+# FLUENT
+from fluent.utils import find_closest_supported_language
+
+
+class UtilsTestCase(TestCase):
+
+    def test_find_closest_supported_language(self):
+        """ Test the `find_closest_supported_language` function. """
+        # If the language code matches exactly, then it should just be returned
+        with override_settings(LANGUAGES=[('en', 'English')]):
+            self.assertEqual(find_closest_supported_language("en"), "en")
+
+        # Same exact matching logic applies to 2-part language codes
+        with override_settings(LANGUAGES=[('en-us', 'English')]):
+            self.assertEqual(find_closest_supported_language("en-us"), "en-us")
+
+        # If the language code is in 2 parts and the first half matches one of the supported
+        # languages then it should return that supported language
+        with override_settings(LANGUAGES=[('en', 'English')]):
+            self.assertEqual(find_closest_supported_language("en-us"), "en")
+
+        # If the language code matches the first half of one of the supported languages then it
+        # should return that supported language
+        with override_settings(LANGUAGES=[('en-us', 'English')]):
+            self.assertEqual(find_closest_supported_language("en"), "en-us")
+
+        # If there is no sensible match then it should raise ValueError
+        with override_settings(LANGUAGES=[('fr', 'Francais')]):
+            self.assertRaises(ValueError, find_closest_supported_language, "en")

--- a/fluent/utils.py
+++ b/fluent/utils.py
@@ -2,7 +2,7 @@ from django.conf import settings
 
 
 def find_closest_supported_language(language_code):
-    lookup = dict(settings.LANGUAGES)
+    lookup = dict(settings.LANGUAGES).keys()
 
     # If it's in there, return this supported language
     if language_code in lookup:
@@ -17,6 +17,8 @@ def find_closest_supported_language(language_code):
         # Finally, if there is another dialect with the same root language
         # then return that, otherwise raise an error
         check = "{}-".format(root_language)
-        return (x for x in root_language.keys() if x.startswith(check)).next()
+        return (x for x in lookup if x.startswith(check)).next()
     except StopIteration:
-        raise ValueError("Unable to find a suitable match for language_code: {}".format(language_code))
+        raise ValueError(
+            "Unable to find a suitable match for language_code: {}".format(language_code)
+        )


### PR DESCRIPTION
The functionality to fall back to another language with the same root (but different dialect) never worked.  It was trying to access `.keys()` on a string.