### PR TITLE
Set `on_delete=DO_NOTHING` as the default for TranslatableCharField.

### DIFF
--- a/fluent/fields.py
+++ b/fluent/fields.py
@@ -125,6 +125,8 @@ class TranslatableCharField(models.ForeignKey):
 
         kwargs["related_name"] = "+" # Disable reverse relations
         kwargs["null"] = True # We need to make this nullable for translations which haven't been set yet
+        if "on_delete" not in kwargs:
+            kwargs["on_delete"] = models.DO_NOTHING
 
         # Only FK to MasterTranslation
         super(TranslatableCharField, self).__init__(MasterTranslation, *args, **kwargs)

--- a/fluent/tests/test_fields.py
+++ b/fluent/tests/test_fields.py
@@ -88,6 +88,13 @@ class TranslatableCharFieldTests(TestCase):
         obj = mommy.make(TestModel)
         self.assertTrue(obj.trans.text)
 
+    def test_delete_does_nothing(self):
+        """ Test that deleting a MasterTranslation does not delete the model which uses it. """
+        TestModel.objects.create(trans=TranslatableContent("whatever"))
+        self.assertEqual(TestModel.objects.count(), 1)
+        MasterTranslation.objects.all().delete()
+        self.assertEqual(TestModel.objects.count(), 1)
+
 
 class TestLocatingTranslatableFields(TestCase):
     def test_find_all_translatable_fields(self):


### PR DESCRIPTION
Otherwise, deleting the MasterTranslationObjects from the DB will delete your actual models, which is unlikely to be what you want or expect.