### PR TITLE
Mastertranslation find by groups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 fluent/.storage
 /libs
 .DS_Store
+.idea

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-  </component>
-</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/fluent/fields.py
+++ b/fluent/fields.py
@@ -4,6 +4,8 @@ from django.db import models
 from django.db import IntegrityError
 from django import forms
 
+from djangae.utils import deprecated
+
 from .models import MasterTranslation
 from .forms import widgets
 
@@ -307,13 +309,17 @@ def find_installed_translatable_fields(with_groups=None):
     return translatable_fields_by_model
 
 
+@deprecated(find_installed_translatable_fields.__name__)
 def find_all_translatable_fields(with_group=None):
     """
         Deprecated. Use find_installed_translatable_fields().
     """
     # Proxy to find_installed_translatable_fields and convert dict response to list of tuples
     translatable_fields = []
-    translatable_fields_by_model = find_installed_translatable_fields(with_groups=[with_group])
+    if with_group:
+        translatable_fields_by_model = find_installed_translatable_fields(with_groups=[with_group])
+    else:
+        translatable_fields_by_model = find_installed_translatable_fields()
     for model, mt_ids in translatable_fields_by_model.items():
         translatable_fields.extend([(model, mt_id) for mt_id in mt_ids])
 

--- a/fluent/fields.py
+++ b/fluent/fields.py
@@ -284,7 +284,7 @@ class TranslatableTextField(TranslatableCharField):
         return super(TranslatableTextField, self).formfield(**defaults)
 
 
-def find_all_translatable_fields(with_groups=None):
+def find_installed_translatable_fields(with_groups=None):
     """
         Scans Django's model registry to find all the Translatable(Char|Text)Fields in use,
         along with their models. This allows us to query for all master translations
@@ -302,3 +302,10 @@ def find_all_translatable_fields(with_groups=None):
     else:
         # Filter by group
         return [ (x.model, x) for x in translatable_fields if x.group in with_groups ]
+
+
+def find_all_translatable_fields(with_group=None):
+    """
+        Deprecated. Use find_installed_translatable_fields().
+    """
+    find_installed_translatable_fields(with_groups=[with_group])

--- a/fluent/fields.py
+++ b/fluent/fields.py
@@ -284,7 +284,7 @@ class TranslatableTextField(TranslatableCharField):
         return super(TranslatableTextField, self).formfield(**defaults)
 
 
-def find_all_translatable_fields(with_group=None):
+def find_all_translatable_fields(with_groups=None):
     """
         Scans Django's model registry to find all the Translatable(Char|Text)Fields in use,
         along with their models. This allows us to query for all master translations
@@ -297,8 +297,8 @@ def find_all_translatable_fields(with_group=None):
     # Note that TranslatableTextField is a subclass of TranslatableCharField, so this works fine
     translatable_fields = [x for x in all_fields if isinstance(x, TranslatableCharField) ]
 
-    if with_group is None:
+    if with_groups is None:
         return [ (x.model, x) for x in translatable_fields ]
     else:
         # Filter by group
-        return [ (x.model, x) for x in translatable_fields if x.group == with_group ]
+        return [ (x.model, x) for x in translatable_fields if x.group in with_groups ]

--- a/fluent/fields.py
+++ b/fluent/fields.py
@@ -290,22 +290,31 @@ def find_installed_translatable_fields(with_groups=None):
         along with their models. This allows us to query for all master translations
         with a particular group.
     """
-
     # FIXME: Internal API, should find a nicer way
     all_fields = MasterTranslation._meta._relation_tree
 
-    # Note that TranslatableTextField is a subclass of TranslatableCharField, so this works fine
-    translatable_fields = [x for x in all_fields if isinstance(x, TranslatableCharField) ]
+    translatable_fields_by_model = {}
+    for field in all_fields:
+        # Note that TranslatableTextField is a subclass of TranslatableCharField, so this works fine
+        if isinstance(field, TranslatableCharField):
+            # If groups specified, check membership
+            if with_groups and field.group not in with_groups:
+                continue
+            if field.model not in translatable_fields_by_model:
+                translatable_fields_by_model[field.model] = []
+            translatable_fields_by_model[field.model].append(field)
 
-    if with_groups is None:
-        return [ (x.model, x) for x in translatable_fields ]
-    else:
-        # Filter by group
-        return [ (x.model, x) for x in translatable_fields if x.group in with_groups ]
+    return translatable_fields_by_model
 
 
 def find_all_translatable_fields(with_group=None):
     """
         Deprecated. Use find_installed_translatable_fields().
     """
-    find_installed_translatable_fields(with_groups=[with_group])
+    # Proxy to find_installed_translatable_fields and convert dict response to list of tuples
+    translatable_fields = []
+    translatable_fields_by_model = find_installed_translatable_fields(with_groups=[with_group])
+    for model, mt_ids in translatable_fields_by_model.items():
+        translatable_fields.extend([(model, mt_id) for mt_id in mt_ids])
+
+    return translatable_fields

--- a/fluent/models.py
+++ b/fluent/models.py
@@ -151,14 +151,14 @@ class MasterTranslation(models.Model):
     @classmethod
     def find_by_groups(cls, groups):
         from .fields import find_installed_translatable_fields
-        translatable_fields = find_installed_translatable_fields(with_groups=groups)
+        translatable_fields_by_model = find_installed_translatable_fields(with_groups=groups)
 
         # Go through all Translatable(Char|Text)Fields or TextFields marked with the specified group and get
         # all the master translation IDs which are set to them
         master_translation_ids = []
-        for model, field in translatable_fields:
+        for model, fields in translatable_fields_by_model.items():
             master_translation_ids.extend(
-                model.objects.values_list(field.attname, flat=True)
+                model.objects.values_list(*[field.attname for field in fields])
             )
             master_translation_ids = list(set(master_translation_ids))
 

--- a/fluent/models.py
+++ b/fluent/models.py
@@ -1,3 +1,4 @@
+from itertools import chain
 from hashlib import md5
 
 from django.db import models
@@ -157,9 +158,7 @@ class MasterTranslation(models.Model):
         # all the master translation IDs which are set to them
         master_translation_ids = []
         for model, fields in translatable_fields_by_model.items():
-            master_translation_ids.extend(
-                model.objects.values_list(*[field.attname for field in fields])
-            )
+            master_translation_ids.extend(chain(*model.objects.values_list(*[field.attname for field in fields])))
             master_translation_ids = list(set(master_translation_ids))
 
         # Now get all the master translations with a group specified in the templates

--- a/fluent/models.py
+++ b/fluent/models.py
@@ -150,8 +150,8 @@ class MasterTranslation(models.Model):
 
     @classmethod
     def find_by_groups(cls, groups):
-        from .fields import find_all_translatable_fields
-        translatable_fields = find_all_translatable_fields(with_groups=groups)
+        from .fields import find_installed_translatable_fields
+        translatable_fields = find_installed_translatable_fields(with_groups=groups)
 
         # Go through all Translatable(Char|Text)Fields or TextFields marked with the specified group and get
         # all the master translation IDs which are set to them
@@ -164,7 +164,7 @@ class MasterTranslation(models.Model):
 
         # Now get all the master translations with a group specified in the templates
         master_translation_ids.extend(
-            list(MasterTranslation.objects.filter(used_by_groups_in_code_or_templates__overlaps=groups)
+            list(MasterTranslation.objects.filter(used_by_groups_in_code_or_templates__overlap=groups)
                  .values_list("pk", flat=True))
         )
 
@@ -176,7 +176,7 @@ class MasterTranslation(models.Model):
 
     @classmethod
     def find_by_group(cls, group_name):
-        return cls.find_by_group([group_name])
+        return cls.find_by_groups([group_name])
 
     @staticmethod
     def generate_key(text, hint, language_code):

--- a/fluent/tests/test_fields.py
+++ b/fluent/tests/test_fields.py
@@ -136,7 +136,7 @@ class TestLocatingTranslatableFields(TestCase):
 
         # Should return the one field with this group
         self.assertEqual(1, len(fluent_app_translatable_fields))
-        self.assertEqual(TestModel, results[0].model)
+        self.assertEqual(TestModel, fluent_app_translatable_fields[0].model)
 
 
 class TranslatableContentTestCase(unittest.TestCase):

--- a/fluent/tests/test_fields.py
+++ b/fluent/tests/test_fields.py
@@ -103,7 +103,7 @@ class TestLocatingTranslatableFields(TestCase):
         self.assertEqual(TestModel, results[2][0])
         self.assertEqual(TestModel, results[3][0])
 
-        results = find_all_translatable_fields(with_group="Test")
+        results = find_all_translatable_fields(with_groups=["Test"])
         # Just filter the results down to this app
         results = [ x for x in results if x[0]._meta.app_label == "fluent" ]
 

--- a/fluent/tests/test_fields.py
+++ b/fluent/tests/test_fields.py
@@ -6,7 +6,8 @@ from djangae.test import TestCase
 from fluent.fields import (
     TranslatableCharField,
     TranslatableContent,
-    find_all_translatable_fields
+    find_all_translatable_fields,
+    find_installed_translatable_fields
 )
 from fluent.models import MasterTranslation
 from fluent.patches import monkey_patch
@@ -103,13 +104,39 @@ class TestLocatingTranslatableFields(TestCase):
         self.assertEqual(TestModel, results[2][0])
         self.assertEqual(TestModel, results[3][0])
 
-        results = find_all_translatable_fields(with_groups=["Test"])
+        results = find_all_translatable_fields(with_group="Test")
         # Just filter the results down to this app
         results = [ x for x in results if x[0]._meta.app_label == "fluent" ]
 
         # Should return the one field with this group
         self.assertEqual(1, len(results))
         self.assertEqual(TestModel, results[0][0])
+
+    def test_find_installed_translatable_fields(self):
+        results = find_installed_translatable_fields()
+
+        # Just filter the results down to this app
+        fluent_app_translatable_fields = []
+        for model in results:
+            if model._meta.app_label == 'fluent':
+                fluent_app_translatable_fields.extend(results[model])
+
+        # Should return the 4 fields of TestModel above
+        self.assertEqual(4, len(fluent_app_translatable_fields))
+        self.assertEqual(TestModel, fluent_app_translatable_fields[0].model)
+        self.assertEqual(TestModel, fluent_app_translatable_fields[1].model)
+        self.assertEqual(TestModel, fluent_app_translatable_fields[2].model)
+        self.assertEqual(TestModel, fluent_app_translatable_fields[3].model)
+
+        results = find_installed_translatable_fields(with_groups=["Test"])
+        fluent_app_translatable_fields = []
+        for model in results:
+            if model._meta.app_label == 'fluent':
+                fluent_app_translatable_fields.extend(results[model])
+
+        # Should return the one field with this group
+        self.assertEqual(1, len(fluent_app_translatable_fields))
+        self.assertEqual(TestModel, results[0].model)
 
 
 class TranslatableContentTestCase(unittest.TestCase):


### PR DESCRIPTION
* Added `find_installed_translatable_fields()` in `fields.py` that copies implementation of `find_all_translatable_fields()` but instead takes a `with_groups` parameter and performs list membership to check if the master translation group is in the specified list of groups.
* `find_all_translatable_fields()` now proxies to `find_installed_translatable_fields()`.
* Similarly, added `find_by_groups()` class method on `MasterTranslation` model that again copies the implementation of `find_by_group`, which now is a proxy to the new `find_by_groups()`.
* Marked `find_all_translatable_fields()` as deprecated (just in the docstring, not sure if theres a more formal way to do this). Didn't do this for the `MasterTranslation` model as `find_by_group()` is much more likely to be in common use and provides a clean shortcut to the real method.