### PR TITLE
Add `mock` and friends to requirements.txt file.

### DIFF
--- a/fluent/tests/test_scanner.py
+++ b/fluent/tests/test_scanner.py
@@ -1,5 +1,5 @@
 import uuid
-from mock import patch, mock_open, Mock
+from mock import patch, mock_open
 
 from djangae.contrib import sleuth
 from djangae.test import TestCase

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,6 @@ Django<1.9
 git+https://github.com/potatolondon/djangae.git#egg=djangae
 model_mommy
 polib
+mock
+pbr
+funcsigs


### PR DESCRIPTION
The use of mock was added in 75a8102ce2de6b796496293b5f31dbfc661c9c67, but it wasn't added to the requirements file.

We use `mock_open` so it's not simple to use `sleuth` instead.