### PR TITLE
Catch JSON errors when importing ARB file.

### DIFF
--- a/fluent/importexport.py
+++ b/fluent/importexport.py
@@ -75,8 +75,12 @@ def import_translations_from_arb(file_in, language_code):
 
         The data keys should match our MasterTranslation pk's.
     """
-    data = json.loads(file_in.read())
     errors = []
+    try:
+        data = json.loads(file_in.read())
+    except ValueError:
+        errors.append(("Badly formatted ARB file", "", ""))
+        return errors
 
     for k, v in data.iteritems():
         if k.startswith("@") and not k.startswith("@@"):

--- a/fluent/tests/test_importexport.py
+++ b/fluent/tests/test_importexport.py
@@ -1,10 +1,18 @@
 # -*- coding: utf-8 -*-
+# STANDARD LIB
+from StringIO import StringIO
+
+# THIRD PARTY
 from djangae.test import TestCase
 import polib
 
-from fluent.importexport import import_translations_from_po
-from fluent.importexport import export_translations_to_po
-from fluent.models import MasterTranslation, Translation
+# FLUENT
+from fluent.importexport import(
+    import_translations_from_po,
+    export_translations_to_po,
+    import_translations_from_arb,
+)
+from fluent.models import MasterTranslation
 
 
 POFILE = '''# Test pofile
@@ -112,3 +120,15 @@ class ExportPOTestCase(TestCase):
         )
 
         self.assertEqual(result, expected)
+
+
+class ImportARBTestCase(TestCase):
+
+    def test_import_translations_from_arb_logs_error_for_invalid_json(self):
+        """ If an ARB file with invalid JSON in it is used, that should be logged as an error. """
+        input_file = StringIO()
+        input_file.write(''' {] ''')  # invalid JSON
+        errors = import_translations_from_arb(input_file, "fr")
+        # We expect there to be one error
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(errors[0][0], "Badly formatted ARB file")


### PR DESCRIPTION
Previously the error would not be caught, so if this function was being run in a deferred task then it would just continuously retry with no way to relay the error back to the user.