### PR TITLE
Improve triggering and finishing of tasks for file scanning.

### DIFF
--- a/fluent/scanner.py
+++ b/fluent/scanner.py
@@ -217,6 +217,9 @@ def parse_file(content, extension):
 
 
 def _scan_list(marshall, scan_id, filenames):
+    """ Given a list of filenames (file paths), of templates and/or python files, scan them for
+        translatable strings and create corresponding MasterTranslation objects.
+    """
     # FIXME: Need to clean up the translations which aren't in use anymore
 
     for filename in filenames:
@@ -279,6 +282,9 @@ def _scan_list(marshall, scan_id, filenames):
 
 
 def begin_scan(marshall):
+    """ Trigger tasks to scan template files and python files for translatable strings and to
+        create corresponding MasterTranslation objects for them.
+    """
     try:
         marshall.refresh_from_db()
     except ScanMarshall.DoesNotExist:


### PR DESCRIPTION
This fixes 2 issues:

1. This now avoids a bug which we used to have where we incremented the number of files to scan gradually as we deferred the task for each chunk, and so if the first task finished before we deferred the second task then it would incorrectly mark the scan as done.
2. It helps prevent the scanning tasks from unnecessarily failing and retrying when colliding with the other tasks while trying to decrement the number of files left to scan.