### PR TITLE
Caching of master translations

### DIFF
--- a/fluent/admin.py
+++ b/fluent/admin.py
@@ -31,9 +31,9 @@ class MasterTranslationAdmin(admin.ModelAdmin):
     def get_urls(self):
         urls = super(MasterTranslationAdmin, self).get_urls()
 
-        urls = ('',
+        urls = ['',
             url(r'scan/$', scan_view, name="fluent_translation_scan"),
-        ) + urls
+        ] + urls
 
         return urls
 

--- a/fluent/admin.py
+++ b/fluent/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 from django.shortcuts import render, redirect
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from djangae.db import transaction
 
@@ -31,7 +31,7 @@ class MasterTranslationAdmin(admin.ModelAdmin):
     def get_urls(self):
         urls = super(MasterTranslationAdmin, self).get_urls()
 
-        urls = patterns('',
+        urls = ('',
             url(r'scan/$', scan_view, name="fluent_translation_scan"),
         ) + urls
 

--- a/fluent/fields.py
+++ b/fluent/fields.py
@@ -8,7 +8,7 @@ from django import forms
 from djangae.utils import deprecated
 
 from .models import MasterTranslation
-from .forms import widgets
+from . import trans
 
 
 class TranslatableContent(object):
@@ -98,8 +98,8 @@ class TranslatableContent(object):
             By automatically rendering the translated text it means that in terms of rendering in
             templates a TranslatableCharField can be treated the same as a CharField.
         """
-        language = get_language()
-        return self.text_for_language_code(language)
+        self._load_master_translation()
+        return trans._get_trans(self._text, self._hint)
 
     def __str__(self):
         return unicode(self).encode('utf-8')
@@ -118,12 +118,10 @@ class TranslatableContent(object):
         return self.text
 
     def text_for_language_code(self, language_code):
+        # We'll keep this, since maybe someone uses it, but language should be switched via
+        # translation activate/deactivate
         self._load_master_translation()
-        if self._master_translation_cache:
-            return self._master_translation_cache.text_for_language_code(language_code)
-        else:
-            # we don't have a master translation (or it failed to load)
-            return self.text
+        return trans._get_trans(self._text, self._hint, language_code)
 
     def save(self):
         if self.is_effectively_null:

--- a/fluent/fields.py
+++ b/fluent/fields.py
@@ -130,7 +130,7 @@ class TranslatableContent(object):
         # We'll keep this, since maybe someone uses it, but language should be switched via
         # translation activate/deactivate
         self._load_master_translation()
-        return trans._get_trans(self._text, self._hint, language_code)
+        return trans._get_trans(self._text, self._hint, language_override=language_code)
 
     def save(self):
         if self.is_effectively_null:

--- a/fluent/fields.py
+++ b/fluent/fields.py
@@ -157,7 +157,7 @@ class TranslatableCharField(models.ForeignKey):
             kwargs["on_delete"] = models.DO_NOTHING
 
         # Only FK to MasterTranslation
-        super(TranslatableCharField, self).__init__(MasterTranslation, *args, **kwargs)
+        super(TranslatableCharField, self).__init__("fluent.MasterTranslation", *args, **kwargs)
 
     def deconstruct(self):
         name, path, args, kwargs = super(TranslatableCharField, self).deconstruct()

--- a/fluent/templatetags/fluent.py
+++ b/fluent/templatetags/fluent.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 from django import template
 from django.templatetags.i18n import do_translate, do_block_translate, TranslateNode
-from django.utils.translation import get_language, trim_whitespace
+from django.utils.translation import trim_whitespace
 from django.template.defaultfilters import force_escape, safe as safe_filter
 from django.utils.html import conditional_escape
 

--- a/fluent/tests/test_fields.py
+++ b/fluent/tests/test_fields.py
@@ -179,15 +179,15 @@ class TranslatableContentTestCase(TestCase):
     def test_str_with_active_language(self):
         """ If there's a currently-active language, str should return the translated text. """
 
-        def mock_text_for_language_code(self, language_code):
+        def mock_get_translation(text, hint, language_code):
             if language_code == "de":
-                return "translated"
-            return self.text
+                return {"singular": "translated", "o": "translated"}
+            return {"singular": self.text}
 
         translation.activate("de")
         with sleuth.switch(
-            "fluent.fields.TranslatableContent.text_for_language_code",
-            mock_text_for_language_code
+            "fluent.fields.trans.TRANSLATION_CACHE.get_translation",
+            mock_get_translation
         ):
             obj = TranslatableContent(text=u'\xc5ukasz')
             result = str(obj)
@@ -205,15 +205,15 @@ class TranslatableContentTestCase(TestCase):
     def test_unicode_with_active_language(self):
         """ If there's a currently-active language, unicode should return the translated text. """
 
-        def mock_text_for_language_code(self, language_code):
+        def mock_get_translation(text, hint, language_code):
             if language_code == "de":
-                return "translated"
-            return self.text
+                return {"singular": "translated", "o": "translated"}
+            return {"singular": self.text}
 
         translation.activate("de")
         with sleuth.switch(
-            "fluent.fields.TranslatableContent.text_for_language_code",
-            mock_text_for_language_code
+            "fluent.fields.trans.TRANSLATION_CACHE.get_translation",
+            mock_get_translation
         ):
             obj = TranslatableContent(text=u'\xc5ukasz')
             result = unicode(obj)

--- a/fluent/tests/test_scanner.py
+++ b/fluent/tests/test_scanner.py
@@ -40,6 +40,8 @@ _('Plural string with hint and group', 'plural', 2, 'hint', group='public')"""
 class ScannerTests(TestCase):
 
     def setUp(self):
+        super(ScannerTests, self).setUp()
+
         TRANSLATION_CACHE.invalidate()
 
     def test_basic_html_parsing(self):

--- a/fluent/trans.py
+++ b/fluent/trans.py
@@ -153,6 +153,10 @@ def _get_trans(text, hint, count=1, language_override=None):
     from django.utils.translation import get_language
 
     language_code = language_override or get_language()
+    # With translations deactivated return the original text
+    # Currently this will be the singular form even for pluralized messages
+    if language_code is None:
+        return unicode(text)
 
     forms = TRANSLATION_CACHE.get_translation(text, hint, language_code)
 

--- a/fluent/trans.py
+++ b/fluent/trans.py
@@ -158,6 +158,13 @@ def _get_trans(text, hint, count=1, language_override=None):
     if language_code is None:
         return unicode(text)
 
+    assert(text is not None)
+
+    # If no text was specified, there won't be a master translation for it
+    # so just return the empty text (we check for not
+    if not text:
+        return u""
+
     forms = TRANSLATION_CACHE.get_translation(text, hint, language_code)
 
     if not forms:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django<1.9
+Django<1.11
 git+https://github.com/potatolondon/djangae.git#egg=djangae
 model_mommy
 polib

--- a/runtests.py
+++ b/runtests.py
@@ -41,6 +41,7 @@ ALWAYS_MIDDLEWARE_CLASSES = (
 
 
 settings.configure(
+    TEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'APP_DIRS': True}],
     SECRET_KEY = "django_tests_secret_key",
     DEBUG = False,
     TEMPLATE_DEBUG = False,


### PR DESCRIPTION
Fixes #24

Change summary:

 - Models with `TranslatableCharField` etc. now get an autogenerated field called _fluent_cache which is a djangae.JSONField that stores field master translation info to prevent unnecessary lookups when rendering content
 - All translation fetching uses the translation cache where possible
 - This also fixes escaping translations which seemed to randomly fail depending on the system they were run on 
 - Updated to support Django 1.10