### PR TITLE
Multiple fixes

### DIFF
--- a/fluent/fields.py
+++ b/fluent/fields.py
@@ -147,7 +147,7 @@ class TranslatableContent(object):
 
 
 class TranslatableCharField(models.ForeignKey):
-    def __init__(self, hint=u"", group=None, *args, **kwargs):
+    def __init__(self, to=None, hint=u"", group=None, *args, **kwargs):
         self.hint = hint
         self.group = group
 
@@ -162,7 +162,6 @@ class TranslatableCharField(models.ForeignKey):
     def deconstruct(self):
         name, path, args, kwargs = super(TranslatableCharField, self).deconstruct()
 
-        del kwargs["to"]
         del kwargs["related_name"]
         del kwargs["null"]
 

--- a/fluent/models.py
+++ b/fluent/models.py
@@ -68,6 +68,12 @@ class Translation(models.Model):
     def __unicode__(self):
         return u"Translation of {} for {}".format(self.denorm_master_text, self.language_code)
 
+    def __repr__(self):
+        """
+        Define an ASCII string safe representation of the translation.
+        """
+        return str("{}".format(self.id))
+
     @staticmethod
     def generate_hash(master_text, master_hint):
         assert master_text
@@ -132,6 +138,12 @@ class MasterTranslation(models.Model):
 
     def __unicode__(self):
         return u"{} ({}{})".format(self.text, self.language_code, ' plural' if self.is_plural else '')
+
+    def __repr__(self):
+        """
+        Define an ASCII string safe representation of the master translation.
+        """
+        return str("{}".format(self.id))
 
     def get_display(self):
         from fluent.trans import _get_trans

--- a/fluent/tests/test_models.py
+++ b/fluent/tests/test_models.py
@@ -110,7 +110,7 @@ class TranslationTests(TestCase):
         )
         translation = mt.translations.get()
 
-        self.assertEqual(unicode(translation), "Hello (en)")
+        self.assertEqual(unicode(translation), "Translation of Hello for en")
 
     def test_unicode_magic_plural(self):
         mt = MasterTranslation.objects.create(
@@ -121,7 +121,7 @@ class TranslationTests(TestCase):
         )
         translation = mt.translations.get()
 
-        self.assertEqual(unicode(translation), "Hello (en plural)")
+        self.assertEqual(unicode(translation), "Translation of Hello for en")
 
     def test_repr(self):
         mt = MasterTranslation.objects.create(

--- a/fluent/tests/test_models.py
+++ b/fluent/tests/test_models.py
@@ -80,6 +80,16 @@ class MasterTranslationTests(TestCase):
 
         self.assertEqual(unicode(mt), "Hello (en plural)")
 
+    def test_repr(self):
+        mt = MasterTranslation.objects.create(
+            text="Hello",
+            plural_text={"h": "Helloes"},
+            hint="World!",
+            language_code="en"
+        )
+
+        self.assertEqual(repr(mt), "{}".format(mt.id))
+
     def test_first_letter_is_not_a_whitespace(self):
         mt = MasterTranslation.objects.create(
             text="\n\n\nHello",
@@ -98,9 +108,9 @@ class TranslationTests(TestCase):
             hint="World!",
             language_code="en"
         )
-        translation = Translation.objects.get()
+        translation = mt.translations.get()
 
-        self.assertEqual(unicode(mt), "Hello (en)")
+        self.assertEqual(unicode(translation), "Hello (en)")
 
     def test_unicode_magic_plural(self):
         mt = MasterTranslation.objects.create(
@@ -109,9 +119,19 @@ class TranslationTests(TestCase):
             hint="World!",
             language_code="en"
         )
-        translation = Translation.objects.get()
+        translation = mt.translations.get()
 
-        self.assertEqual(unicode(mt), "Hello (en plural)")
+        self.assertEqual(unicode(translation), "Hello (en plural)")
+
+    def test_repr(self):
+        mt = MasterTranslation.objects.create(
+            text="Hello",
+            hint="World!",
+            language_code="en"
+        )
+        translation = mt.translations.get()
+
+        self.assertEqual(repr(translation), "{}".format(translation.id))
 
     def test_clean(self):
         MasterTranslation.objects.create(text="Buttons!")

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ polib
 mock
 pbr
 funcsigs
+django-test-without-migrations==0.6

--- a/runtests.py
+++ b/runtests.py
@@ -23,6 +23,7 @@ CUSTOM_INSTALLED_APPS = (
 )
 
 ALWAYS_INSTALLED_APPS = (
+    'test_without_migrations',
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sessions',
@@ -89,8 +90,9 @@ else:
 args.append(test_cases)
 # ``verbosity`` can be overwritten from command line.
 args.append('--verbosity=2')
+args.append('--nomigrations')
 args.extend(sys.argv[offset:])
 
-from djangae.core.management import execute_from_command_line
+from djangae.core.management import test_execute_from_command_line
 
-execute_from_command_line(args)
+test_execute_from_command_line(args)


### PR DESCRIPTION
- Fixed tests so that they actually run again
- Fixed a bug with ``TranslatableCharField`` that meant django was exploding when deconstructing it
- Fixed tests for ``Translation`` model that were actually testing and comparing the wrong things
- Added ``__repr__`` method to both ``MasterTranslation`` and ``Translation`` models so that the models can be safely run through MapReduce task pipelines without blowing up
- Added tests for the new ``__repr__`` methods.
