### PR TITLE
Make codebase Python 3 compatible 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,9 @@ language: python
 sudo: false
 python:
         - 2.7
+        - 3.7
 install:
+        - pip install future
         - python install_deps.py
 script:
         - python runtests.py

--- a/fluent/__init__.py
+++ b/fluent/__init__.py
@@ -1,2 +1,3 @@
+from __future__ import unicode_literals
 
 default_app_config = 'fluent.apps.FluentAppConfig'

--- a/fluent/admin.py
+++ b/fluent/admin.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from django.contrib import admin
 from django.shortcuts import render, redirect
 from django.conf.urls import url

--- a/fluent/apps.py
+++ b/fluent/apps.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 
 
 from django.apps import AppConfig

--- a/fluent/cldr/__init__.py
+++ b/fluent/cldr/__init__.py
@@ -67,6 +67,8 @@ to our cldr functions.
 Using that we can match indexed ordered forms to codenamed cldr forms allowing for *.po import and export.
 
 """
+from __future__ import unicode_literals
+from builtins import zip
 import re
 from decimal import Decimal, InvalidOperation
 from collections import OrderedDict
@@ -77,7 +79,7 @@ from fluent.cldr.rules import get_plural_index, get_rules_for_language
 # Trying to keep the the data small
 _json_kw = ZERO, ONE, TWO, FEW, MANY, OTHER = 'zotfmh'
 _icu_kw = 'zero', 'one', 'two', 'few', 'many', 'other'
-ICU_KEYWORDS = OrderedDict(zip(_icu_kw, _json_kw))
+ICU_KEYWORDS = OrderedDict(list(zip(_icu_kw, _json_kw)))
 
 
 #RE_FORMAT_SYMBOLS = re.compile(r'(?<!%)(?:%%)*%s')
@@ -114,7 +116,7 @@ def _export_plurals(plurals):
             keyword_parts.append(" %s {%s}" % (icu_key, message))
     # The remaining keys in the dictionary are numbers
     for key in sorted(plurals.keys()):
-        assert isinstance(key, (int, long))
+        assert isinstance(key, (int, int))
         message = _icu_encode(plurals.pop(key))
         parts.append(" =%s {%s}" % (key, message))
 
@@ -141,13 +143,13 @@ def export_translation_message(trans, only_used=False):
         return _icu_encode(trans.plurals[singular_form])
 
     if only_used:
-        plurals = dict((form, t) for (form, t) in trans.plurals.iteritems() if form in lookup_fun.plurals_used)
+        plurals = dict((form, t) for (form, t) in trans.plurals.items() if form in lookup_fun.plurals_used)
     else:
         plurals = dict(trans.plurals)
 
     if len(plurals) == 1:
         # if there's only one plural form it has to be the singular translation
-        return _icu_encode(plurals.values()[0])
+        return _icu_encode(list(plurals.values())[0])
     return _export_plurals(plurals)
 
 

--- a/fluent/cldr/expr_parser.py
+++ b/fluent/cldr/expr_parser.py
@@ -12,6 +12,10 @@
     This parser is based on Fredrik Lundh's (effbot.org) adaptation of Douglas Crockford's
     adaptation of Vaughan Pratt's topdown parser algorithm.
 """
+from __future__ import unicode_literals
+from builtins import map
+from builtins import next
+from builtins import object
 import re
 
 
@@ -35,7 +39,7 @@ class SymbolBase(object):
         elif self.id == "literal":
             return "(%s %s)" % (self.id, self.value)
         out = [self.id, self.first, self.second, self.third]
-        out = map(str, filter(None, out))
+        out = list(map(str, [_f for _f in out if _f]))
         return "(" + " ".join(out) + ")"
 
 
@@ -82,7 +86,7 @@ def prefix(id, bp):
 def advance(i, id=None):
     if id and i.current.id != id:
         raise SyntaxError("Expected %r" % id)
-    i.next()
+    next(i)
 
 
 def method(s):
@@ -131,10 +135,10 @@ def led(self, i, left):
 class tokenize(object):
     def __init__(self, str_expr):
         self.generator = self.split(str_expr)
-        self.next()
+        next(self)
 
-    def next(self):
-        self.current = self.generator.next()
+    def __next__(self):
+        self.current = next(self.generator)
         return self
 
     def split(self, str_expr):
@@ -161,9 +165,9 @@ class tokenize(object):
 
 # parser engine
 def expression(i, rbp=0):
-    left = i.current.nud(i.next())
+    left = i.current.nud(next(i))
     while rbp < i.current.lbp:
-        left = i.current.led(i.next(), left)
+        left = i.current.led(next(i), left)
     return left
 
 

--- a/fluent/cldr/rules.py
+++ b/fluent/cldr/rules.py
@@ -11,7 +11,9 @@
     The gettext rules are also probably common so we should respect their exact form and ordering of plurals.
     For each lookup function we keep a mapping from gettext indexes to our form codenames (gettext_forms).
 """
+from __future__ import unicode_literals
 
+from builtins import range
 ZERO, ONE, TWO, FEW, MANY, OTHER = 'zotfmh'
 LANGUAGE_LOOKUPS = {}
 
@@ -24,7 +26,7 @@ def example_numbers(lookup_fun, fractions=True):
     seen_plurals = set()
     result = []
 
-    test = range(1, 100) + [0]
+    test = list(range(1, 100)) + [0]
     if fractions:
         test.append(0.1)
     for i in test:
@@ -50,7 +52,7 @@ def _parse_value(value):
     if value == '':
         value = 1
 
-    if isinstance(value, (int, long)):
+    if isinstance(value, (int, int)):
         return value, value, 0, 0, 0, 0
 
     str_value = repr(value).split('.')

--- a/fluent/cldr/validation.py
+++ b/fluent/cldr/validation.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import re
 from fluent.cldr.rules import get_plural_index
 

--- a/fluent/fields.py
+++ b/fluent/fields.py
@@ -1,4 +1,8 @@
 # -*- coding: utf8 -*-
+from __future__ import unicode_literals
+from builtins import str
+from past.builtins import basestring
+from builtins import object
 from django.conf import settings
 from django.db import models
 from django.db import IntegrityError
@@ -111,7 +115,7 @@ class TranslatableContent(object):
         return trans._get_trans(self._text, self._hint)
 
     def __str__(self):
-        return unicode(self).encode('utf-8')
+        return str(self).encode('utf-8')
 
     def __repr__(self):
         short_text = self.text[:30]

--- a/fluent/forms/__init__.py
+++ b/fluent/forms/__init__.py
@@ -1,4 +1,6 @@
+from __future__ import unicode_literals
 
+from builtins import object
 from .fields import TranslatableCharField
 from . import widgets
 

--- a/fluent/forms/fields.py
+++ b/fluent/forms/fields.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+from past.builtins import basestring
 from django import forms
 from django.conf import settings
 

--- a/fluent/forms/widgets.py
+++ b/fluent/forms/widgets.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 from django.conf import settings
 from django.forms.widgets import (
     MultiWidget,

--- a/fluent/importexport.py
+++ b/fluent/importexport.py
@@ -1,4 +1,8 @@
+from __future__ import unicode_literals
 #LIBRARIES
+from builtins import map
+from builtins import str
+from builtins import object
 import time
 import json
 import polib
@@ -61,10 +65,10 @@ def get_used_fields(plurals, language_code):
     lookup = get_rules_for_language(language_code)
     missing = set(lookup.plurals_used) - set(plurals)
     if missing:
-        RK = dict((v, k) for (k, v) in cldr.ICU_KEYWORDS.items())
+        RK = dict((v, k) for (k, v) in list(cldr.ICU_KEYWORDS.items()))
         raise ValueError("Missing keywords required by language: %s" % ', '.join(map(RK.get, missing)))
     return dict((keyword, form)
-        for (keyword, form) in plurals.items()
+        for (keyword, form) in list(plurals.items())
         if keyword.startswith('=') or keyword in lookup.plurals_used
     )
 
@@ -78,11 +82,11 @@ def import_translations_from_arb(file_in, language_code):
     errors = []
     try:
         data = json.loads(file_in.read())
-    except ValueError, e:
+    except ValueError as e:
         errors.append((u"Badly formatted ARB file: {0}".format(e.message), "", ""))
         return errors
 
-    for k, v in data.iteritems():
+    for k, v in data.items():
         if k.startswith("@") and not k.startswith("@@"):
             pk = k.lstrip("@")
             try:
@@ -101,7 +105,7 @@ def import_translations_from_arb(file_in, language_code):
                 plurals = cldr.import_icu_message(plurals_data)
                 if master.is_plural:
                     plurals = get_used_fields(plurals, language_code)
-            except ValueError, e:
+            except ValueError as e:
                 errors.append((e.message, master.text, data[str(pk)]))
                 continue
 
@@ -173,7 +177,7 @@ def import_translations_from_po(file_contents, language_code, from_language):
     """
     if isinstance(file_contents, str):
         # if we're passing in a str, convert to unicode
-        file_contents = unicode(file_contents, 'utf-8')
+        file_contents = str(file_contents, 'utf-8')
 
     pofile = polib.pofile(file_contents, encoding='utf-8')
     errors = []
@@ -244,7 +248,7 @@ def export_translations_to_po(language_code):
     return response
 
 
-class OutputFormat:
+class OutputFormat(object):
     ARB = 'ARB'
     PO = 'PO'
     CSV = 'CSV'

--- a/fluent/models.py
+++ b/fluent/models.py
@@ -1,3 +1,6 @@
+from __future__ import unicode_literals
+from builtins import str
+from builtins import object
 from itertools import chain
 from hashlib import md5
 
@@ -27,7 +30,7 @@ class ScanMarshall(models.Model):
         else:
             return super(ScanMarshall, self).save(*args, **kwargs)
 
-    class Meta:
+    class Meta(object):
         app_label = "fluent"
 
 
@@ -43,7 +46,7 @@ class Translation(models.Model):
 
     master_text_hint_hash = models.CharField(max_length=64)
 
-    class Meta:
+    class Meta(object):
         app_label = "fluent"
 
     @property
@@ -152,7 +155,7 @@ class MasterTranslation(models.Model):
 
     def text_for_language_code(self, lang_code):
         new_code = find_closest_supported_language(lang_code)
-        if new_code not in self.translations_by_language_code.keys():
+        if new_code not in list(self.translations_by_language_code.keys()):
             # we don't have a translation for this language
             return self.text
 
@@ -252,7 +255,7 @@ class MasterTranslation(models.Model):
 
     def create_or_update_translation(self, language_code, singular_text=None, plural_texts=None, validate=False):
 
-        if language_code not in dict(settings.LANGUAGES).keys():
+        if language_code not in list(dict(settings.LANGUAGES).keys()):
             return ["'{}' is not included as a language in your settings file".format(language_code)]
 
         with transaction.atomic(xg=True):
@@ -294,5 +297,5 @@ class MasterTranslation(models.Model):
                 self.translations.add(trans)
                 self.save()
 
-    class Meta:
+    class Meta(object):
         app_label = "fluent"

--- a/fluent/patches.py
+++ b/fluent/patches.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import sys
 import os
 
@@ -59,7 +60,7 @@ def monkey_patch():
             sys.path.insert(0, temp_path)
             additional_mod = import_module(imp)
             sys.path.pop(0)
-        except ImportError, e:
+        except ImportError as e:
             raise ImportError("Could not import additional locale '%s': %s" % (additional_path, e))
         BASE_INFO.update(additional_mod.LANG_INFO)
 

--- a/fluent/scanner.py
+++ b/fluent/scanner.py
@@ -1,3 +1,6 @@
+from __future__ import unicode_literals
+from builtins import str
+from builtins import range
 import django
 import logging
 import os
@@ -228,7 +231,7 @@ def _scan_list(marshall, scan_id, filenames):
             continue
 
         with open(filename) as f:
-            content = unicode(f.read(), settings.DEFAULT_CHARSET)
+            content = str(f.read(), settings.DEFAULT_CHARSET)
 
         results = parse_file(content, os.path.splitext(filename)[-1])
 
@@ -251,7 +254,7 @@ def _scan_list(marshall, scan_id, filenames):
                 mt.used_in_code_or_templates = True
 
                 # If we last updated during this scan, then append, otherwise replace
-                if mt.last_updated_by_scan_uuid == unicode(scan_id):
+                if mt.last_updated_by_scan_uuid == str(scan_id):
                     mt.used_by_groups_in_code_or_templates.add(group)
                 else:
                     mt.used_by_groups_in_code_or_templates = { group }
@@ -262,7 +265,7 @@ def _scan_list(marshall, scan_id, filenames):
     # Update the ScanMarshall object with the reduced number of `files_left_to_process`.
     # Do this with several retries, so that if the transction collides with another task (which is
     # quite likely) this whole task doesn't fail and retry (which would be fine but inefficient).
-    for retry in xrange(3):
+    for retry in range(3):
         try:
             with transaction.atomic():
                 marshall.refresh_from_db()
@@ -325,7 +328,7 @@ def begin_scan(marshall):
         marshall.files_left_to_process += len(files_to_scan)
         marshall.save()
 
-    for offset in xrange(0, len(files_to_scan), 100):
+    for offset in range(0, len(files_to_scan), 100):
         files = files_to_scan[offset:offset + 100]
         # Defer with a random delay of between 0 and 10 seconds, just to avoid transaction
         # collisions caused by the tasks all finishing and updating the marshall at the same time.

--- a/fluent/templatetags/fluent.py
+++ b/fluent/templatetags/fluent.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 
+from builtins import str
 from django import template
 from django.templatetags.i18n import do_translate, do_block_translate, TranslateNode
 from django.utils.translation import trim_whitespace
@@ -20,7 +22,7 @@ class EscapedTranslateNode(TranslateNode):
         # always happen depending on which system the code was run on. I have absolutely
         # no explanation.
         if self.filter_expression.var.literal is not None:
-            self.filter_expression.var.literal = unicode(self.filter_expression.var.literal)
+            self.filter_expression.var.literal = str(self.filter_expression.var.literal)
 
         # Call up to the parent render to render the tag, but then escape the output to
         # prevent any malicous code being run if it is input as a translation

--- a/fluent/tests/test_cldr_rules.py
+++ b/fluent/tests/test_cldr_rules.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import unittest
 
 from fluent.cldr import rules

--- a/fluent/tests/test_fields.py
+++ b/fluent/tests/test_fields.py
@@ -1,4 +1,7 @@
+from __future__ import unicode_literals
 # THIRD PARTY
+from builtins import str
+from builtins import object
 from djangae.contrib import sleuth
 from djangae.test import TestCase
 from django.db import models
@@ -18,7 +21,7 @@ from fluent.patches import monkey_patch
 
 
 class TranslatedModel(models.Model):
-    class Meta:
+    class Meta(object):
         app_label = "fluent"
 
 
@@ -29,7 +32,7 @@ class TranslatedModel(models.Model):
 
 
 class BadDefaultModel(models.Model):
-    class Meta:
+    class Meta(object):
         # don't get counted in the locating test
         app_label = "fluent_test"
 
@@ -197,10 +200,10 @@ class TranslatableContentTestCase(TestCase):
 
     def test_unicode(self):
         obj = TranslatableContent(text=u'\xc5ukasz')
-        result = unicode(obj)
+        result = str(obj)
 
         self.assertEqual(result, u'\xc5ukasz')
-        self.assertIsInstance(result, unicode)
+        self.assertIsInstance(result, str)
 
     def test_unicode_with_active_language(self):
         """ If there's a currently-active language, unicode should return the translated text. """
@@ -216,7 +219,7 @@ class TranslatableContentTestCase(TestCase):
             mock_get_translation
         ):
             obj = TranslatableContent(text=u'\xc5ukasz')
-            result = unicode(obj)
+            result = str(obj)
 
         self.assertEqual(result, u'translated')
-        self.assertIsInstance(result, unicode)
+        self.assertIsInstance(result, str)

--- a/fluent/tests/test_importexport.py
+++ b/fluent/tests/test_importexport.py
@@ -1,6 +1,10 @@
 # -*- coding: utf-8 -*-
 # STANDARD LIB
-from StringIO import StringIO
+from __future__ import unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+from builtins import str
+from io import StringIO
 
 # THIRD PARTY
 from djangae.test import TestCase
@@ -99,7 +103,7 @@ class ExportPOTestCase(TestCase):
             text=u"Something to translate", language_code="en").save()
         MasterTranslation(
             text=u"Product®™ — Special chars", language_code="en").save()
-        po_file = polib.pofile(unicode(
+        po_file = polib.pofile(str(
             export_translations_to_po('en').content.decode('utf-8')))
         self.assertEqual(EXPECTED_EXPORT_PO_FILE, po_file.__unicode__())
 
@@ -109,7 +113,7 @@ class ExportPOTestCase(TestCase):
 
         MasterTranslation(text=u'Foo', hint=u'Bar', language_code='en').save()
 
-        result = unicode(export_translations_to_po('en-US'))
+        result = str(export_translations_to_po('en-US'))
         expected = (
             u'Content-Type: text/plain\r\n'
             u'Content-Disposition: attachment; filename=django.po\r\n\r\n'

--- a/fluent/tests/test_models.py
+++ b/fluent/tests/test_models.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+from builtins import str
 from djangae.test import TestCase
 from django.conf import settings
 from django.core.exceptions import ValidationError
@@ -68,7 +70,7 @@ class MasterTranslationTests(TestCase):
             language_code="en"
         )
 
-        self.assertEqual(unicode(mt), "Hello (en)")
+        self.assertEqual(str(mt), "Hello (en)")
 
     def test_unicode_magic_plural(self):
         mt = MasterTranslation.objects.create(
@@ -78,7 +80,7 @@ class MasterTranslationTests(TestCase):
             language_code="en"
         )
 
-        self.assertEqual(unicode(mt), "Hello (en plural)")
+        self.assertEqual(str(mt), "Hello (en plural)")
 
     def test_repr(self):
         mt = MasterTranslation.objects.create(
@@ -110,7 +112,7 @@ class TranslationTests(TestCase):
         )
         translation = mt.translations.get()
 
-        self.assertEqual(unicode(translation), "Translation of Hello for en")
+        self.assertEqual(str(translation), "Translation of Hello for en")
 
     def test_unicode_magic_plural(self):
         mt = MasterTranslation.objects.create(
@@ -121,7 +123,7 @@ class TranslationTests(TestCase):
         )
         translation = mt.translations.get()
 
-        self.assertEqual(unicode(translation), "Translation of Hello for en")
+        self.assertEqual(str(translation), "Translation of Hello for en")
 
     def test_repr(self):
         mt = MasterTranslation.objects.create(

--- a/fluent/tests/test_plurals.py
+++ b/fluent/tests/test_plurals.py
@@ -1,8 +1,13 @@
 # -*- coding: utf-8 -*-
 #SYSTEM
+from __future__ import unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+from builtins import map
+from builtins import range
 import re
 import json
-from StringIO import StringIO
+from io import StringIO
 import os.path
 import xml.etree.ElementTree as ET
 
@@ -30,7 +35,7 @@ class TestPluralRules(TestCase):
 
         #lang_dict = getattr(settings, "ALTERNATIVES_DICT", dict((x, x) for x, y in settings.LANGUAGES))
         # we don't have rules for those languages
-        SUPPORTED_LANGUAGES = LANGUAGE_LOOKUPS.keys()
+        SUPPORTED_LANGUAGES = list(LANGUAGE_LOOKUPS.keys())
 
         # Parse the xml and come up with a dict of example values:
         cls.examples = []
@@ -56,11 +61,11 @@ class TestPluralRules(TestCase):
 
                 if t is int:
                     for range_text in re.findall(r'([0-9]+~[0-9]+)', example_set):
-                        r_start, r_end = map(int, range_text.split('~'))
-                        example_values.extend(range(r_start, r_end))
+                        r_start, r_end = list(map(int, range_text.split('~')))
+                        example_values.extend(list(range(r_start, r_end)))
 
                 values_list = re.sub(u'~|,|…', ' ', example_set).split()[1:]
-                example_values.extend(map(t, values_list))
+                example_values.extend(list(map(t, values_list)))
                 data[cldr.ICU_KEYWORDS[rule.attrib['count']]] = set(example_values)
             cls.examples.append(data)
 

--- a/fluent/tests/test_scanner.py
+++ b/fluent/tests/test_scanner.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import uuid
 from mock import patch, mock_open
 

--- a/fluent/tests/test_trans.py
+++ b/fluent/tests/test_trans.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import datetime
 
 from djangae.contrib import sleuth

--- a/fluent/tests/test_utils.py
+++ b/fluent/tests/test_utils.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 # THIRD PARTY
 from djangae.test import TestCase
 from django.test import override_settings

--- a/fluent/utils.py
+++ b/fluent/utils.py
@@ -1,8 +1,10 @@
+from __future__ import unicode_literals
+from builtins import next
 from django.conf import settings
 
 
 def find_closest_supported_language(language_code):
-    lookup = dict(settings.LANGUAGES).keys()
+    lookup = list(dict(settings.LANGUAGES).keys())
 
     # If it's in there, return this supported language
     if language_code in lookup:
@@ -17,7 +19,7 @@ def find_closest_supported_language(language_code):
         # Finally, if there is another dialect with the same root language
         # then return that, otherwise raise an error
         check = "{}-".format(root_language)
-        return (x for x in lookup if x.startswith(check)).next()
+        return next((x for x in lookup if x.startswith(check)))
     except StopIteration:
         raise ValueError(
             "Unable to find a suitable match for language_code: {}".format(language_code)

--- a/install_deps.py
+++ b/install_deps.py
@@ -1,12 +1,16 @@
 #!/usr/bin/env python
+from __future__ import print_function
+from __future__ import unicode_literals
+from future import standard_library
+standard_library.install_aliases()
 import os
 import stat
 import subprocess
 import shutil
 
-from StringIO import StringIO
+from io import BytesIO
 from zipfile import ZipFile
-from urllib import urlopen
+from urllib.request import urlopen
 
 
 PROJECT_DIR = os.path.abspath(os.path.dirname(__file__))
@@ -41,7 +45,7 @@ if __name__ == '__main__':
         if sdk_file.getcode() >= 299:
             raise Exception('App Engine SDK could not be found. {} returned code {}.'.format(sdk_file.geturl(), sdk_file.getcode()))
 
-        zipfile = ZipFile(StringIO(sdk_file.read()))
+        zipfile = ZipFile(BytesIO(sdk_file.read()))
         zipfile.extractall(TARGET_DIR)
 
         #Make sure the dev_appserver and appcfg are executable

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ mock
 pbr
 funcsigs
 django-test-without-migrations==0.6
+pytz

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pbr
 funcsigs
 django-test-without-migrations==0.6
 pytz
+future

--- a/runtests.py
+++ b/runtests.py
@@ -42,14 +42,27 @@ ALWAYS_MIDDLEWARE_CLASSES = (
 
 
 settings.configure(
-    TEMPLATES = [{'BACKEND': 'django.template.backends.django.DjangoTemplates', 'APP_DIRS': True}],
+    TEMPLATES = [
+        {
+            'BACKEND': 'django.template.backends.django.DjangoTemplates',
+            'DIRS': [],
+            'APP_DIRS': True,
+            'OPTIONS': {
+                'context_processors': [
+                    'django.template.context_processors.debug',
+                    'django.template.context_processors.request',
+                    'django.contrib.auth.context_processors.auth',
+                    'django.contrib.messages.context_processors.messages',
+                ],
+            },
+        }
+    ],
     SECRET_KEY = "django_tests_secret_key",
     DEBUG = False,
     TEMPLATE_DEBUG = False,
     ALLOWED_HOSTS = [],
     INSTALLED_APPS = ALWAYS_INSTALLED_APPS + CUSTOM_INSTALLED_APPS,
     MIDDLEWARE_CLASSES = ALWAYS_MIDDLEWARE_CLASSES,
-    ROOT_URLCONF = 'tests.urls',
     DATABASES = {
         'default': {
             'ENGINE': 'djangae.db.backends.appengine',

--- a/runtests.py
+++ b/runtests.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import unicode_literals
 import glob
 import os
 import sys

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import os
 from setuptools import setup, find_packages
 


### PR DESCRIPTION
[Futurize](http://python-future.org/futurize.html#forwards-conversion-stage1 )used to refactor codebase to be compatible with Python 3:

* `futurize --stage1 -w -n --no-diffs --unicode-literals`
* `futurize --stage2 -w -n --no-diffs`

NB: tests will not pass until djangae has been made Python 3 compatible + remove dependency on the GAE SDK.